### PR TITLE
Included support for console history

### DIFF
--- a/cmd/attach.go
+++ b/cmd/attach.go
@@ -48,7 +48,7 @@ account does not exist, the command will fail.`,
 			}
 		}
 
-		cs := console.New(loadedAddress)
+		cs := console.New(loadedAddress, consoleHistoryFilePath)
 		err = cs.DialRPCServer(rpcAddress)
 		if err != nil {
 			log.Fatal("unable to start RPC server", "Err", err)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -32,13 +32,14 @@ import (
 )
 
 var (
-	cfg         *configdir.Config
-	log         logger.Logger
-	devMode     bool
-	sigs        chan os.Signal
-	done        chan bool
-	accountMgr  *accountmgr.AccountManager
-	onTerminate func()
+	cfg                    *configdir.Config
+	consoleHistoryFilePath string
+	log                    logger.Logger
+	devMode                bool
+	sigs                   chan os.Signal
+	done                   chan bool
+	accountMgr             *accountmgr.AccountManager
+	onTerminate            func()
 )
 
 // rootCmd represents the base command when called without any subcommands
@@ -100,4 +101,5 @@ func initConfig() {
 
 	cfg.Node.Test = false
 	accountMgr = accountmgr.New(path.Join(cfg.ConfigDir(), "accounts"))
+	consoleHistoryFilePath = path.Join(cfg.ConfigDir(), ".console_history")
 }

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -211,7 +211,7 @@ func start(cmd *cobra.Command, args []string, startConsole bool) (*node.Node, *r
 	var cs *console.Console
 	if startConsole {
 
-		cs = console.New(loadedAddress)
+		cs = console.New(loadedAddress, consoleHistoryFilePath)
 
 		if startRPC {
 

--- a/console/completer.go
+++ b/console/completer.go
@@ -22,15 +22,13 @@ var commonFunc = [][]string{
 
 // SuggestionManager manages suggestions
 type SuggestionManager struct {
-	initialSuggestions []prompt.Suggest
-	suggestions        []prompt.Suggest
+	suggestions []prompt.Suggest
 }
 
 // NewSuggestionManager creates a suggestion manager. Initialize suggestions
 // by providing initial suggestion as argument
 func NewSuggestionManager(initialSuggestions []prompt.Suggest) *SuggestionManager {
 	sm := new(SuggestionManager)
-	sm.initialSuggestions = initialSuggestions
 	sm.suggestions = initialSuggestions
 	return sm
 }

--- a/console/console.go
+++ b/console/console.go
@@ -1,7 +1,9 @@
 package console
 
 import (
+	"encoding/json"
 	"fmt"
+	"io/ioutil"
 	"net/rpc"
 	"runtime"
 
@@ -16,25 +18,37 @@ import (
 // an interactive Javascript console to perform and query
 // the system.
 type Console struct {
-	prompt     *prompt.Prompt
-	executor   *Executor
-	suggestMgr *SuggestionManager
-	rpcClient  *rpc.Client
-	signatory  *crypto.Key
+	prompt      *prompt.Prompt
+	executor    *Executor
+	suggestMgr  *SuggestionManager
+	rpcClient   *rpc.Client
+	signatory   *crypto.Key
+	historyFile string
+	history     []string
 }
 
 // New creates a new Console instance.
 // signatory is the address
-func New(signatory *crypto.Key) *Console {
+func New(signatory *crypto.Key, historyFilePath string) *Console {
 
 	c := new(Console)
+	c.historyFile = historyFilePath
 	c.executor = NewExecutor()
 	c.suggestMgr = NewSuggestionManager(initialSuggestions)
 	c.executor.spell = spell.NewSpell(signatory)
 
+	var history []string
+	histBs, _ := ioutil.ReadFile(historyFilePath)
+	if len(histBs) > 0 {
+		json.Unmarshal(histBs, &history)
+	}
+
+	histOpt := prompt.OptionHistory(history)
+
 	exitKeyBind := prompt.KeyBind{
 		Key: prompt.ControlC,
 		Fn: func(*prompt.Buffer) {
+			c.saveHistory()
 			c.executor.exitProgram(false)
 		},
 	}
@@ -46,9 +60,13 @@ func New(signatory *crypto.Key) *Console {
 		prompt.OptionDescriptionTextColor(prompt.White),
 		prompt.OptionSuggestionTextColor(prompt.Turquoise),
 		prompt.OptionSuggestionBGColor(prompt.Black),
+		histOpt,
 	}
 
-	c.prompt = prompt.New(c.executor.OnInput, c.suggestMgr.completer, options...)
+	c.prompt = prompt.New(func(in string) {
+		c.history = append(c.history, in)
+		c.executor.OnInput(in)
+	}, c.suggestMgr.completer, options...)
 
 	return c
 }
@@ -77,6 +95,7 @@ func (c *Console) Run() {
 
 // Exit stops console by killing the process
 func (c *Console) Exit() {
+	c.saveHistory()
 	c.executor.exitProgram(true)
 }
 
@@ -85,4 +104,15 @@ func (c *Console) about() {
 	fmt.Println(fmt.Sprintf("Client:%s, Protocol:%s, Go:%s", util.ClientVersion, util.ProtocolVersion, runtime.Version()))
 	fmt.Println(" type '.exit' to exit console")
 	fmt.Println("")
+}
+
+func (c *Console) saveHistory() {
+	if len(c.history) == 0 {
+		return
+	}
+	bs, _ := json.Marshal(c.history)
+	err := ioutil.WriteFile(c.historyFile, bs, 0644)
+	if err != nil {
+		panic(err)
+	}
 }

--- a/console/executor.go
+++ b/console/executor.go
@@ -58,6 +58,7 @@ func (e *Executor) OnInput(in string) {
 	case ".help":
 		e.help()
 	default:
+		
 		e.exec(in)
 	}
 }


### PR DESCRIPTION
All console commands are not collected into to .console_history file and loaded during console initialization. This is a feature that will make testing a lot easier.