### PR TITLE
Remove BeforeAppend Callback in TxPool 

### DIFF
--- a/txpool/txpool_test.go
+++ b/txpool/txpool_test.go
@@ -57,21 +57,20 @@ var _ = Describe("TxPool", func() {
 			Expect(tp.queue.Size()).To(Equal(int64(1)))
 		})
 
-		It("should return nil and call onQueueCB function ", func() {
-			onQueueFuncCalled := false
+		It("should emit core.EventNewTransaction", func() {
 			tp := NewTxPool(1)
-			tp.BeforeAppend(func(tx core.Transaction) error {
-				onQueueFuncCalled = true
-				return nil
-			})
 			a, _ := crypto.NewKey(nil)
 			tx := wire.NewTransaction(wire.TxTypeBalance, 1, "something", util.String(a.PubKey().Base58()), "0", "0", time.Now().Unix())
-			sig, _ := wire.TxSign(tx, a.PrivKey().Base58())
-			tx.Sig = sig
-			err := tp.Put(tx)
-			Expect(err).To(BeNil())
-			Expect(tp.queue.Size()).To(Equal(int64(1)))
-			Expect(onQueueFuncCalled).To(BeTrue())
+			go func() {
+				GinkgoRecover()
+				sig, _ := wire.TxSign(tx, a.PrivKey().Base58())
+				tx.Sig = sig
+				err := tp.Put(tx)
+				Expect(err).To(BeNil())
+				Expect(tp.queue.Size()).To(Equal(int64(1)))
+			}()
+			event := <-tp.event.Once(core.EventNewTransaction)
+			Expect(event.Args[0]).To(Equal(tx))
 		})
 	})
 

--- a/types/core/events.go
+++ b/types/core/events.go
@@ -7,4 +7,8 @@ const (
 	// EventNewBlock represents an event about a new block
 	// that was successfully added to the main chain
 	EventNewBlock = "event.newBlock"
+
+	// EventNewTransaction  represents an event about a new
+	// transaction that was received 
+	EventNewTransaction = "event.newTx"
 )


### PR DESCRIPTION
* TxPool will no longer support the `BeforeAppend` callback which allowed transactions to be broadcast before inclusion to a block.
* Instead, a `core.EventNewTransaction` is emitted with the transaction passed to it.
* Fixed broken test.