### PR TITLE
Added new RPC methods to `node` package.

### DIFF
--- a/cmd/start.go
+++ b/cmd/start.go
@@ -51,7 +51,7 @@ func loadOrCreateAccount(account, password string, seed int64) (*crypto.Key, err
 	var address *crypto.Key
 	var err error
 	var storedAccount *accountmgr.StoredAccount
-
+	
 	if account != "" {
 		if govalidator.IsNumeric(account) {
 			aInt, err := strconv.Atoi(account)

--- a/node/api.go
+++ b/node/api.go
@@ -4,27 +4,82 @@ import (
 	"github.com/ellcrys/elld/rpc"
 	"github.com/ellcrys/elld/rpc/jsonrpc"
 	"github.com/ellcrys/elld/types"
+	"github.com/ellcrys/elld/util"
 	"github.com/ellcrys/elld/wire"
-	"github.com/ncodes/mapstructure"
 )
+
+// apiSendTx sends adds a transaction to transaction pool
+func (n *Node) apiSendTx(params interface{}) *jsonrpc.Response {
+
+	p, ok := params.(map[string]interface{})
+	if !ok {
+		return jsonrpc.Error(types.ErrCodeUnexpectedArgType, rpc.ErrMethodArgType("JSON").Error(), nil)
+	}
+
+	var tx wire.Transaction
+	util.MapDecode(p, &tx)
+
+	return jsonrpc.Success(n.addTransaction(&tx))
+}
+
+// apiJoin attempts to establish connection with a node
+// at the specified address.
+func (n *Node) apiJoin(arg interface{}) *jsonrpc.Response {
+
+	address, ok := arg.(string)
+	if !ok {
+		return jsonrpc.Error(types.ErrCodeUnexpectedArgType, rpc.ErrMethodArgType("String").Error(), nil)
+	}
+
+	n.AddBootstrapNodes([]string{address}, true)
+	rn, err := n.NodeFromAddr(address, true)
+	if err != nil {
+		return jsonrpc.Error(types.ErrCodeAddress, err.Error(), nil)
+	}
+	rn.isHardcodedSeed = true
+
+	if err := n.connectToNode(rn); err != nil {
+		return jsonrpc.Error(types.ErrCodeNodeConnect, err.Error(), nil)
+	}
+
+	return jsonrpc.Success(nil)
+}
+
+// apiNumConnections returns the number of peers connected to
+func (n *Node) apiNumConnections(arg interface{}) *jsonrpc.Response {
+	return jsonrpc.Success(n.peerManager.connMgr.connectionCount())
+}
+
+// apiGetActivePeers fetches active peers
+func (n *Node) apiGetActivePeers(arg interface{}) *jsonrpc.Response {
+	var peers = []map[string]interface{}{}
+	for _, p := range n.peerManager.GetActivePeers(0) {
+		peers = append(peers, map[string]interface{}{
+			"id":          p.StringID(),
+			"lastSeen":    p.GetTimestamp(),
+			"connected":   p.Connected(),
+			"isHardcoded": p.IsHardcodedSeed(),
+		})
+	}
+	return jsonrpc.Success(peers)
+}
 
 // APIs returns all API handlers
 func (n *Node) APIs() jsonrpc.APISet {
 	return map[string]jsonrpc.APIInfo{
-		"TransactionAdd": jsonrpc.APIInfo{
+		"sendTx": jsonrpc.APIInfo{
 			Private: true,
-			Func: func(params interface{}) *jsonrpc.Response {
-
-				p, ok := params.(map[string]interface{})
-				if !ok {
-					return jsonrpc.Error(types.ErrCodeUnexpectedArgType, rpc.ErrMethodArgType("JSON").Error(), nil)
-				}
-
-				var tx wire.Transaction
-				mapstructure.Decode(p, &tx)
-
-				return jsonrpc.Success(n.addTransaction(&tx))
-			},
+			Func:    n.apiSendTx,
+		},
+		"join": jsonrpc.APIInfo{
+			Private: true,
+			Func:    n.apiJoin,
+		},
+		"numConnections": jsonrpc.APIInfo{
+			Func: n.apiNumConnections,
+		},
+		"getActivePeers": jsonrpc.APIInfo{
+			Func: n.apiGetActivePeers,
 		},
 	}
 }

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -127,7 +127,7 @@ func NodeTest() bool {
 				Expect(err).To(BeNil())
 				_, err = n.NodeFromAddr("/invalid", false)
 				Expect(err).ToNot(BeNil())
-				Expect(err.Error()).To(Equal("addr is not valid"))
+				Expect(err.Error()).To(Equal("invalid address provided"))
 			})
 		})
 

--- a/node/peer_mgr.go
+++ b/node/peer_mgr.go
@@ -437,15 +437,19 @@ func (m *Manager) CreatePeerFromAddress(addr string) error {
 
 	var err error
 
-	// Ensure the address is a valid address format
-	if !util.IsValidAddr(addr) {
-		return fmt.Errorf("failed to create peer from address. Peer address is invalid")
+	if err = validateAddress(m.localNode, addr); err != nil {
+		return err
 	}
 
-	// In production mode, the address must be routable
-	if m.localNode.ProdMode() && !util.IsRoutableAddr(addr) {
-		return fmt.Errorf("failed to create peer from address. Peer address is invalid")
-	}
+	// // Ensure the address is a valid address format
+	// if !util.IsValidAddr(addr) {
+	// 	return fmt.Errorf("failed to create peer from address. Peer address is invalid")
+	// }
+
+	// // In production mode, the address must be routable
+	// if m.localNode.ProdMode() && !util.IsRoutableAddr(addr) {
+	// 	return fmt.Errorf("failed to create peer from address. Peer address is invalid")
+	// }
 
 	// The peer must not already exists be known
 	mAddr, _ := ma.NewMultiaddr(addr)

--- a/node/peer_mgr_test.go
+++ b/node/peer_mgr_test.go
@@ -282,16 +282,16 @@ func PeerManagerTest() bool {
 		Describe(".CreatePeerFromAddress", func() {
 			address := "/ip4/127.0.0.1/tcp/40004/ipfs/12D3KooWHHzSeKaY8xuZVzkLbKFfvNgPPeKhFBGrMbNzbm5akpqd"
 
-			It("peer return error.Error('failed to create peer from address. Peer address is invalid') when address is /ip4/127.0.0.1/tcp/4000", func() {
+			It("peer return err='not a valid multiaddr' when address is /ip4/127.0.0.1/tcp/4000", func() {
 				err := mgr.CreatePeerFromAddress("/ip4/127.0.0.1/tcp/4000")
 				Expect(err).NotTo(BeNil())
-				Expect(err.Error()).To(Equal("failed to create peer from address. Peer address is invalid"))
+				Expect(err.Error()).To(Equal("not a valid multiaddr"))
 			})
 
-			It("peer return error.Error('failed to create peer from address. Peer address is invalid') when address is /ip4/127.0.0.1/tcp/4000/ipfs", func() {
+			It("peer return err='not a valid multiaddr' when address is /ip4/127.0.0.1/tcp/4000/ipfs", func() {
 				err := mgr.CreatePeerFromAddress("/ip4/127.0.0.1/tcp/4000/ipfs")
 				Expect(err).NotTo(BeNil())
-				Expect(err.Error()).To(Equal("failed to create peer from address. Peer address is invalid"))
+				Expect(err.Error()).To(Equal("not a valid multiaddr"))
 			})
 
 			It("peer with address '/ip4/127.0.0.1/tcp/40004/ipfs/12D3KooWHHzSeKaY8xuZVzkLbKFfvNgPPeKhFBGrMbNzbm5akpqd' must be added", func() {

--- a/rpc/api.go
+++ b/rpc/api.go
@@ -7,13 +7,16 @@ import (
 
 func (s *Server) rpcAuth(params interface{}) *jsonrpc.Response {
 
-	p, ok := params.(map[string]string)
+	p, ok := params.(map[string]interface{})
 	if !ok {
 		return jsonrpc.Error(types.ErrCodeUnexpectedArgType, ErrMethodArgType("JSON").Error(), nil)
 	}
 
+	username, _ := p["username"].(string)
+	password, _ := p["password"].(string)
+
 	// perform authentication and create a session token
-	token, err := s.auth(p["username"], p["password"])
+	token, err := s.auth(username, password)
 	if err != nil {
 		return jsonrpc.Error(types.ErrCodeInvalidAuthCredentials, err.Error(), nil)
 	}

--- a/rpc/jsonrpc/api.go
+++ b/rpc/jsonrpc/api.go
@@ -1,15 +1,13 @@
 package jsonrpc
 
-import (
-	"github.com/mitchellh/mapstructure"
-)
+import "github.com/ellcrys/elld/util"
 
 // Params represent JSON API parameters
 type Params map[string]interface{}
 
 // Scan attempts to convert the params to a struct or map type
 func (p *Params) Scan(dest interface{}) error {
-	return mapstructure.Decode(p, &dest)
+	return util.MapDecode(p, &dest)
 }
 
 // APIInfo defines a standard API function type

--- a/types/engine.go
+++ b/types/engine.go
@@ -43,4 +43,5 @@ type Engine interface {
 	Connected() bool                      // Returns true if engine is connected to its local node
 	GetBlockchain() core.Blockchain       // Returns the blockchain manager
 	SetBlockchain(bchain core.Blockchain) // Set the blockchain manager
+	ProdMode() bool                       // Checks whether the current mode is ModeProd
 }

--- a/types/err_codes.go
+++ b/types/err_codes.go
@@ -14,4 +14,8 @@ const (
 
 	// General
 	ErrCodeUnexpectedArgType = 60000
+
+	// Engine package errors from 70000
+	ErrCodeAddress     = 70000
+	ErrCodeNodeConnect = 70001
 )

--- a/util/common.go
+++ b/util/common.go
@@ -11,6 +11,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/mitchellh/mapstructure"
+
 	"github.com/vmihailenco/msgpack"
 
 	"github.com/fatih/structs"
@@ -251,4 +253,22 @@ func GetPtrAddr(ptrAddr interface{}) *big.Int {
 		panic("could not convert pointer address to big.Int")
 	}
 	return ptrAddrInt
+}
+
+// MapDecode decodes a map to a struct.
+// It uses mapstructure.Decode internally but
+// with 'json' TagName.
+func MapDecode(m interface{}, rawVal interface{}) error {
+	config := &mapstructure.DecoderConfig{
+		Metadata: nil,
+		Result:   rawVal,
+		TagName:  "json",
+	}
+
+	decoder, err := mapstructure.NewDecoder(config)
+	if err != nil {
+		return err
+	}
+
+	return decoder.Decode(m)
 }


### PR DESCRIPTION
* `apiJoin` causes the node to attempt to connect to another peer.
* `apiNumConnections`: returns the number of peers a node is connected to.
* Replace use of `mapstructure.Decode` with customized `util.MapDecode` which uses `json` tags. We don't need to set a different `mapstructure` tag.
* Fixed broken test in `node` package.