### PR TITLE
Address Persistence & RPC Namespace Requirement

### DIFF
--- a/blockchain/common/schema_test.go
+++ b/blockchain/common/schema_test.go
@@ -1,7 +1,6 @@
 package common
 
 import (
-	"github.com/k0kubun/pp"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -87,7 +86,6 @@ var _ = Describe("Schema", func() {
 	Describe(".MakeTreeKey", func() {
 		It("should return expected key", func() {
 			k := MakeTreeKey(10, TagAccount)
-			pp.Println(k)
 			Expect(k).To(Equal([]uint8{
 				0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x0a, 0x61,
 			}))

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -193,13 +193,13 @@ func start(cmd *cobra.Command, args []string, startConsole bool) (*node.Node, *r
 	}
 
 	// Add hardcoded bootstrap addresses
-	if err := n.AddBootstrapNodes(boostrapAddresses, true); err != nil {
+	if err := n.AddAddresses(boostrapAddresses, true); err != nil {
 		log.Fatal("%s", err)
 	}
 
 	// Add bootstrap addresses supplied
 	// in the config file
-	if err := n.AddBootstrapNodes(cfg.Node.BootstrapNodes, false); err != nil {
+	if err := n.AddAddresses(cfg.Node.BootstrapNodes, false); err != nil {
 		log.Fatal("%s", err)
 	}
 

--- a/console/executor.go
+++ b/console/executor.go
@@ -168,7 +168,7 @@ func (e *Executor) PrepareContext() ([]prompt.Suggest, error) {
 	}
 
 	// Get all the rpc methods information
-	resp, err := e.rpc.Client.call("methods", nil, e.authToken)
+	resp, err := e.rpc.Client.call("rpc_methods", nil, e.authToken)
 	if err != nil {
 		e.log.Error(color.RedString(RPCClientError(err.Error()).Error()))
 		return suggestions, err
@@ -206,7 +206,7 @@ func (e *Executor) PrepareContext() ([]prompt.Suggest, error) {
 				arg = args[0]
 			}
 
-			result, err := e.callRPCMethod(mName, arg)
+			result, err := e.callRPCMethod(ns+"_"+mName, arg)
 			if err != nil {
 				e.log.Error(color.RedString(RPCClientError(err.Error()).Error()))
 				v, _ := otto.ToValue(nil)

--- a/console/executor.go
+++ b/console/executor.go
@@ -72,7 +72,7 @@ func (e *Executor) login(username, password string) interface{} {
 	}
 
 	// Call the auth RPC method
-	rpcResp, err := e.rpc.Client.call("auth", arg, "")
+	rpcResp, err := e.rpc.Client.call("admin_auth", arg, "")
 	if err != nil {
 		e.log.Error(color.RedString(RPCClientError(err.Error()).Error()))
 		v, _ := otto.ToValue(nil)

--- a/node/addr.go
+++ b/node/addr.go
@@ -1,7 +1,6 @@
 package node
 
 import (
-	"context"
 	"fmt"
 	"math/big"
 	"sort"
@@ -15,21 +14,24 @@ import (
 	ma "github.com/multiformats/go-multiaddr"
 )
 
-// onAddr processes "addr" message
+// onAddr processes wire.Addr message
 func (g *Gossip) onAddr(s net.Stream) ([]*wire.Address, error) {
 
-	remoteAddr := util.FullRemoteAddressFromStream(s)
+	remoteAddr := util.RemoteAddressFromStream(s)
 	remotePeer := NewRemoteNode(remoteAddr, g.engine)
 	remotePeerIDShort := remotePeer.ShortID()
 
-	// read message from the stream
 	resp := &wire.Addr{}
 	if err := ReadStream(s, resp); err != nil {
 		g.log.Debug("Failed to read Addr response response", "Err", err, "PeerID", remotePeerIDShort)
 		return nil, fmt.Errorf("failed to read Addr response: %s", err)
 	}
 
-	// we need to ensure the amount of addresses does not exceed the max. address expected
+	g.PM().UpdatePeerTime(remotePeer)
+
+	// we need to ensure the amount of
+	// addresses does not exceed the
+	// maximum address expected
 	if int64(len(resp.Addresses)) > g.engine.cfg.Node.MaxAddrsExpected {
 		g.log.Debug("Too many addresses received. Ignoring addresses", "PeerID", remotePeerIDShort, "NumAddrReceived", len(resp.Addresses))
 		return nil, fmt.Errorf("too many addresses received. Ignoring addresses")
@@ -58,37 +60,42 @@ func (g *Gossip) onAddr(s net.Stream) ([]*wire.Address, error) {
 		}
 	}
 
-	g.log.Info("Received Addr message from peer", "PeerID",
-		remotePeerIDShort, "NumAddrs", len(resp.Addresses), "InvalidAddrs", invalidAddrs)
+	g.log.Info("Received Addr message from peer",
+		"PeerID", remotePeerIDShort,
+		"NumAddrs", len(resp.Addresses),
+		"InvalidAddrs", invalidAddrs)
 
 	return resp.Addresses, nil
 }
 
-// OnAddr handles incoming addr wire.
+// OnAddr handles incoming wire.Addr message.
 // Received addresses are relayed.
 func (g *Gossip) OnAddr(s net.Stream) {
 
 	defer s.Close()
 
-	remoteAddr := util.FullRemoteAddressFromStream(s)
+	remoteAddr := util.RemoteAddressFromStream(s)
 	remotePeer := NewRemoteNode(remoteAddr, g.engine)
 
-	// check whether we are are allowed to interact with the remote peer
+	// check whether we are are allowed to
+	//  interact with the remote peer
 	if ok, err := g.engine.canAcceptPeer(remotePeer); !ok {
 		g.log.Debug(fmt.Sprintf("Can't accept message from peer: %s", err.Error()),
 			"Addr", remotePeer.GetMultiAddr(), "Msg", "GetAddr")
 		return
 	}
 
-	// process the stream and return the addresses set
+	// process the stream and return
+	// the addresses set
 	addresses, err := g.onAddr(s)
 	if err != nil {
 		g.engine.event.Emit(EventAddrProcessed, err)
 		return
 	}
 
-	// As long as we have more that one address, we should attempt
-	// to relay it to other peers
+	// As long as we have more that one
+	// address, we should attempt to relay
+	// it/them to other peers
 	if len(addresses) > 0 {
 		go g.RelayAddresses(addresses)
 	}
@@ -97,10 +104,12 @@ func (g *Gossip) OnAddr(s net.Stream) {
 }
 
 // SelectRelayPeers returns two random remote
-// nodes to broadcast <Addr> messages to. These peers
-// are selected from the given candidate address list.
-// The selected peers are cached for up to 24 hours
-// afterwhich peers are reselected.
+// nodes to broadcast wire.Addr messages to.
+// These peers are selected from the given
+// candidate addresses.
+// The selected peers are cached for up to
+// 24 hours after which the peers are
+// reselected.
 func (g *Gossip) SelectRelayPeers(candidates []*wire.Address) []*Node {
 	g.mtx.Lock()
 	defer g.mtx.Unlock()
@@ -178,10 +187,14 @@ func makeAddrRelayHistoryKey(addr *wire.Addr, peer *Node) []interface{} {
 	return []interface{}{util.SerializeMsg(addr), peer.StringID()}
 }
 
-// RelayAddresses relays addrs under the following rules:
-// * "addr" message must contain not more than 10 addrs.
-// * all addresses must be valid and different from the local peer address
-// * Only addresses within 60 minutes from the current time.
+// RelayAddresses relays wire.Address under
+// the following rules:
+// * wire.Address message must contain not more
+//   than 10 addrs.
+// * all addresses must be valid and
+//   different from the local peer address
+// * Only addresses within 60 minutes from
+//   the current time.
 // * Only routable addresses are allowed.
 func (g *Gossip) RelayAddresses(addrs []*wire.Address) []error {
 
@@ -192,7 +205,8 @@ func (g *Gossip) RelayAddresses(addrs []*wire.Address) []error {
 	// Do not proceed if there are more
 	// than 10 addresses
 	if len(addrs) > 10 {
-		errs = append(errs, fmt.Errorf("too many addresses in the message"))
+		errs = append(errs, fmt.Errorf("too many addresses"+
+			" in the message"))
 		return errs
 	}
 
@@ -218,7 +232,8 @@ func (g *Gossip) RelayAddresses(addrs []*wire.Address) []error {
 			continue
 		}
 
-		// In non-production mode, we are allowed to relay non-routable addresses.
+		// In non-production mode, we are allowed
+		// to relay non-routable addresses.
 		// But we can't allow them in production
 		if g.engine.ProdMode() && !util.IsRoutableAddr(addr.Address) {
 			errs = append(errs, fmt.Errorf("address {%s} is not routable", addr.Address))
@@ -256,29 +271,35 @@ func (g *Gossip) RelayAddresses(addrs []*wire.Address) []error {
 
 		historyKey := makeAddrRelayHistoryKey(addrMsg, remotePeer)
 
-		// ensure we have not relayed same message to this peer before
+		// ensure we have not relayed same
+		// message to this peer before
 		if g.engine.history.HasMulti(historyKey...) {
 			errs = append(errs, fmt.Errorf("already sent same Addr to node"))
-			g.log.Debug("Already sent same Addr to node. Skipping.", "PeerID", remotePeer.ShortID())
+			g.log.Debug("Already sent same Addr to node. Skipping.",
+				"PeerID", remotePeer.ShortID())
 			continue
 		}
 
-		ctxDur := time.Second * time.Duration(g.engine.cfg.Node.MessageTimeout)
-		ctx, cf := context.WithTimeout(context.TODO(), ctxDur)
-		defer cf()
-		s, err := g.NewStream(ctx, remotePeer, config.AddrVersion)
+		s, c, err := g.NewStream(remotePeer, config.AddrVersion)
 		if err != nil {
-			errs = append(errs, fmt.Errorf("Addr message failed. failed to connect to peer {%s}", remotePeer.ShortID()))
-			g.log.Debug("Addr message failed. failed to connect to peer", "Err", err, "PeerID", remotePeer.ShortID())
+			errs = append(errs, fmt.Errorf("Addr message failed."+
+				" failed to connect to peer {%s}", remotePeer.ShortID()))
+			g.log.Debug("Addr message failed. failed to connect to peer",
+				"Err", err, "PeerID", remotePeer.ShortID())
 			continue
 		}
+		defer c()
 		defer s.Close()
 
 		if err := WriteStream(s, addrMsg); err != nil {
-			errs = append(errs, fmt.Errorf("Addr failed. failed to write to stream to peer {%s}", remotePeer.ShortID()))
-			g.log.Debug("Addr failed. failed to write to stream", "Err", err, "PeerID", remotePeer.ShortID())
+			errs = append(errs, fmt.Errorf("Addr failed. failed to "+
+				"write to stream to peer {%s}", remotePeer.ShortID()))
+			g.log.Debug("Addr failed. failed to write to stream",
+				"Err", err, "PeerID", remotePeer.ShortID())
 			continue
 		}
+
+		g.PM().UpdatePeerTime(remotePeer)
 
 		// add new history
 		g.engine.history.AddMulti(cache.Sec(600), historyKey...)
@@ -286,7 +307,8 @@ func (g *Gossip) RelayAddresses(addrs []*wire.Address) []error {
 		relayed++
 	}
 
-	g.log.Info("Relay completed", "NumAddrsToRelay", len(relayable), "NumRelayed", relayed)
+	g.log.Debug("Relay completed", "NumAddrsToRelay",
+		len(relayable), "NumRelayed", relayed)
 	defer g.engine.event.Emit(EventAddressesRelayed)
 
 	return errs

--- a/node/addr.go
+++ b/node/addr.go
@@ -52,7 +52,7 @@ func (g *Gossip) onAddr(s net.Stream) ([]*wire.Address, error) {
 		}
 
 		// Add the remote peer to the peer manager's list
-		if g.PM().AddOrUpdatePeer(p) != nil {
+		if g.PM().UpdatePeerTime(p) != nil {
 			invalidAddrs++
 			continue
 		}

--- a/node/addr.go
+++ b/node/addr.go
@@ -48,7 +48,7 @@ func (g *Gossip) onAddr(s net.Stream) ([]*wire.Address, error) {
 		// Check if the timestamp us acceptable according to
 		// the discovery protocol rules
 		if p.IsBadTimestamp() {
-			p.Timestamp = time.Now().Add(-1 * time.Hour * 24 * 5)
+			p.Timestamp = time.Now().UTC().Add(-1 * time.Hour * 24 * 5)
 		}
 
 		// Add the remote peer to the peer manager's list
@@ -105,7 +105,7 @@ func (g *Gossip) SelectRelayPeers(candidates []*wire.Address) []*Node {
 	g.mtx.Lock()
 	defer g.mtx.Unlock()
 
-	now := time.Now()
+	now := time.Now().UTC()
 
 	// If the last time we selected the peers
 	// have not surpassed 24 hours, return the
@@ -168,7 +168,7 @@ func (g *Gossip) SelectRelayPeers(candidates []*wire.Address) []*Node {
 	}
 
 	// Update the relay peer selection time
-	g.relayPeerSelectedAt = time.Now()
+	g.relayPeerSelectedAt = time.Now().UTC()
 
 	return g.RelayPeers
 
@@ -187,7 +187,7 @@ func (g *Gossip) RelayAddresses(addrs []*wire.Address) []error {
 
 	var errs []error
 	var relayable []*wire.Address
-	now := time.Now()
+	now := time.Now().UTC()
 
 	// Do not proceed if there are more
 	// than 10 addresses

--- a/node/addr_test.go
+++ b/node/addr_test.go
@@ -1,7 +1,6 @@
 package node_test
 
 import (
-	"context"
 	"fmt"
 	"time"
 
@@ -223,8 +222,9 @@ var _ = Describe("Addr", func() {
 
 		Context("when the number of addresses is below max address expected", func() {
 			BeforeEach(func() {
-				stream, err := lp.Gossip().NewStream(context.Background(), rp, config.AddrVersion)
+				stream, c, err := lp.Gossip().NewStream(rp, config.AddrVersion)
 				Expect(err).To(BeNil())
+				defer c()
 				defer stream.Close()
 				go func() {
 					defer GinkgoRecover()
@@ -247,8 +247,9 @@ var _ = Describe("Addr", func() {
 
 			BeforeEach(func(done Done) {
 				rp.GetCfg().Node.MaxAddrsExpected = 1
-				stream, err := lp.Gossip().NewStream(context.Background(), rp, config.AddrVersion)
+				stream, c, err := lp.Gossip().NewStream(rp, config.AddrVersion)
 				Expect(err).To(BeNil())
+				defer c()
 				defer stream.Reset()
 				go func() {
 					err := node.WriteStream(stream, addrMsg)

--- a/node/api.go
+++ b/node/api.go
@@ -2,6 +2,7 @@ package node
 
 import (
 	"encoding/base64"
+	"time"
 
 	"github.com/ellcrys/elld/config"
 
@@ -39,25 +40,54 @@ func (n *Node) apiGetConfig(arg interface{}) *jsonrpc.Response {
 	return jsonrpc.Success(n.cfg)
 }
 
-// apiJoin attempts to establish connection with a node
-// at the specified address.
+// apiJoin attempts to establish connection
+// with a node at the specified address.
 func (n *Node) apiJoin(arg interface{}) *jsonrpc.Response {
-
 	address, ok := arg.(string)
 	if !ok {
 		return jsonrpc.Error(types.ErrCodeUnexpectedArgType, rpc.ErrMethodArgType("String").Error(), nil)
 	}
 
-	n.AddBootstrapNodes([]string{address}, true)
 	rp, err := n.NodeFromAddr(address, true)
 	if err != nil {
 		return jsonrpc.Error(types.ErrCodeAddress, err.Error(), nil)
 	}
+
 	rp.isHardcodedSeed = true
+
+	if rp.IsSame(n) {
+		return jsonrpc.Error(types.ErrCodeAddress, "can't add own address as a peer", nil)
+	}
 
 	go func(rp *Node) {
 		n.connectToNode(rp)
 	}(rp)
+
+	return jsonrpc.Success(nil)
+}
+
+// apiAddPeer adds an address of a remote node
+// to the list of known addresses. Unlike apiJoin
+// it does not initiate a connection.
+func (n *Node) apiAddPeer(arg interface{}) *jsonrpc.Response {
+	address, ok := arg.(string)
+	if !ok {
+		return jsonrpc.Error(types.ErrCodeUnexpectedArgType, rpc.ErrMethodArgType("String").Error(), nil)
+	}
+
+	rp, err := n.NodeFromAddr(address, true)
+	if err != nil {
+		return jsonrpc.Error(types.ErrCodeAddress, err.Error(), nil)
+	}
+
+	rp.isHardcodedSeed = true
+	rp.Timestamp = time.Now().UTC()
+
+	if rp.IsSame(n) {
+		return jsonrpc.Error(types.ErrCodeAddress, "can't add self as a peer", nil)
+	}
+
+	n.PM().addPeer(rp)
 
 	return jsonrpc.Success(nil)
 }
@@ -77,10 +107,26 @@ func (n *Node) apiGetActivePeers(arg interface{}) *jsonrpc.Response {
 	var peers = []map[string]interface{}{}
 	for _, p := range n.peerManager.GetActivePeers(0) {
 		peers = append(peers, map[string]interface{}{
-			"id":          p.StringID(),
-			"lastSeen":    p.GetTimestamp(),
-			"connected":   p.Connected(),
-			"isHardcoded": p.IsHardcodedSeed(),
+			"id":           p.StringID(),
+			"lastSeen":     p.GetTimestamp(),
+			"connected":    p.Connected(),
+			"isHardcoded":  p.IsHardcodedSeed(),
+			"isAcquainted": p.IsAcquainted(),
+		})
+	}
+	return jsonrpc.Success(peers)
+}
+
+// apiGetPeers fetches all peers
+func (n *Node) apiGetPeers(arg interface{}) *jsonrpc.Response {
+	var peers = []map[string]interface{}{}
+	for _, p := range n.peerManager.GetPeers() {
+		peers = append(peers, map[string]interface{}{
+			"id":           p.StringID(),
+			"lastSeen":     p.GetTimestamp(),
+			"connected":    p.Connected(),
+			"isHardcoded":  p.IsHardcodedSeed(),
+			"isAcquainted": p.IsAcquainted(),
 		})
 	}
 	return jsonrpc.Success(peers)
@@ -174,10 +220,21 @@ func (n *Node) APIs() jsonrpc.APISet {
 			Private:     true,
 			Func:        n.apiJoin,
 		},
+		"addPeer": {
+			Namespace:   "net",
+			Description: "Add a peer address",
+			Private:     true,
+			Func:        n.apiAddPeer,
+		},
 		"numConnections": {
 			Namespace:   "net",
 			Description: "Get number of active connections",
 			Func:        n.apiNumConnections,
+		},
+		"getPeers": {
+			Namespace:   "net",
+			Description: "Get a list of all peers",
+			Func:        n.apiGetPeers,
 		},
 		"getActivePeers": {
 			Namespace:   "net",

--- a/node/api.go
+++ b/node/api.go
@@ -87,7 +87,7 @@ func (n *Node) apiAddPeer(arg interface{}) *jsonrpc.Response {
 		return jsonrpc.Error(types.ErrCodeAddress, "can't add self as a peer", nil)
 	}
 
-	n.PM().addPeer(rp)
+	n.PM().AddPeer(rp)
 
 	return jsonrpc.Success(nil)
 }

--- a/node/api.go
+++ b/node/api.go
@@ -14,8 +14,8 @@ import (
 	"github.com/ellcrys/elld/util"
 )
 
-// apiBasicNodeInfo returns basic information
-// about the node.
+// apiBasicNodeInfo returns basic
+// information about the node.
 func (n *Node) apiBasicNodeInfo(arg interface{}) *jsonrpc.Response {
 
 	var mode = "development"
@@ -45,7 +45,8 @@ func (n *Node) apiGetConfig(arg interface{}) *jsonrpc.Response {
 func (n *Node) apiJoin(arg interface{}) *jsonrpc.Response {
 	address, ok := arg.(string)
 	if !ok {
-		return jsonrpc.Error(types.ErrCodeUnexpectedArgType, rpc.ErrMethodArgType("String").Error(), nil)
+		return jsonrpc.Error(types.ErrCodeUnexpectedArgType,
+			rpc.ErrMethodArgType("String").Error(), nil)
 	}
 
 	rp, err := n.NodeFromAddr(address, true)
@@ -53,10 +54,9 @@ func (n *Node) apiJoin(arg interface{}) *jsonrpc.Response {
 		return jsonrpc.Error(types.ErrCodeAddress, err.Error(), nil)
 	}
 
-	rp.isHardcodedSeed = true
-
 	if rp.IsSame(n) {
-		return jsonrpc.Error(types.ErrCodeAddress, "can't add own address as a peer", nil)
+		return jsonrpc.Error(types.ErrCodeAddress,
+			"can't add own address as a peer", nil)
 	}
 
 	go func(rp *Node) {
@@ -66,13 +66,15 @@ func (n *Node) apiJoin(arg interface{}) *jsonrpc.Response {
 	return jsonrpc.Success(nil)
 }
 
-// apiAddPeer adds an address of a remote node
-// to the list of known addresses. Unlike apiJoin
-// it does not initiate a connection.
+// apiAddPeer adds an address of a
+// remote node to the list of known
+// addresses. Unlike apiJoin it does
+// not initiate a connection.
 func (n *Node) apiAddPeer(arg interface{}) *jsonrpc.Response {
 	address, ok := arg.(string)
 	if !ok {
-		return jsonrpc.Error(types.ErrCodeUnexpectedArgType, rpc.ErrMethodArgType("String").Error(), nil)
+		return jsonrpc.Error(types.ErrCodeUnexpectedArgType,
+			rpc.ErrMethodArgType("String").Error(), nil)
 	}
 
 	rp, err := n.NodeFromAddr(address, true)
@@ -80,11 +82,11 @@ func (n *Node) apiAddPeer(arg interface{}) *jsonrpc.Response {
 		return jsonrpc.Error(types.ErrCodeAddress, err.Error(), nil)
 	}
 
-	rp.isHardcodedSeed = true
-	rp.Timestamp = time.Now().UTC()
+	rp.lastSeen = time.Now().UTC()
 
 	if rp.IsSame(n) {
-		return jsonrpc.Error(types.ErrCodeAddress, "can't add self as a peer", nil)
+		return jsonrpc.Error(types.ErrCodeAddress,
+			"can't add self as a peer", nil)
 	}
 
 	n.PM().AddPeer(rp)
@@ -92,12 +94,14 @@ func (n *Node) apiAddPeer(arg interface{}) *jsonrpc.Response {
 	return jsonrpc.Success(nil)
 }
 
-// apiNumConnections returns the number of peers connected to
+// apiNumConnections returns the
+// number of peers connected to
 func (n *Node) apiNumConnections(arg interface{}) *jsonrpc.Response {
 	return jsonrpc.Success(n.peerManager.connMgr.connectionCount())
 }
 
-// apiGetSyncQueueSize returns the size of the block hash queue
+// apiGetSyncQueueSize returns the
+// size of the block hash queue
 func (n *Node) apiGetSyncQueueSize(arg interface{}) *jsonrpc.Response {
 	return jsonrpc.Success(n.blockHashQueue.Size())
 }
@@ -108,7 +112,7 @@ func (n *Node) apiGetActivePeers(arg interface{}) *jsonrpc.Response {
 	for _, p := range n.peerManager.GetActivePeers(0) {
 		peers = append(peers, map[string]interface{}{
 			"id":           p.StringID(),
-			"lastSeen":     p.GetTimestamp(),
+			"lastSeen":     p.GetLastSeen(),
 			"connected":    p.Connected(),
 			"isHardcoded":  p.IsHardcodedSeed(),
 			"isAcquainted": p.IsAcquainted(),
@@ -123,7 +127,7 @@ func (n *Node) apiGetPeers(arg interface{}) *jsonrpc.Response {
 	for _, p := range n.peerManager.GetPeers() {
 		peers = append(peers, map[string]interface{}{
 			"id":           p.StringID(),
-			"lastSeen":     p.GetTimestamp(),
+			"lastSeen":     p.GetLastSeen(),
 			"connected":    p.Connected(),
 			"isHardcoded":  p.IsHardcodedSeed(),
 			"isAcquainted": p.IsAcquainted(),
@@ -157,7 +161,8 @@ func (n *Node) apiSend(arg interface{}) *jsonrpc.Response {
 
 	txData, ok := arg.(map[string]interface{})
 	if !ok {
-		return jsonrpc.Error(types.ErrCodeUnexpectedArgType, rpc.ErrMethodArgType("JSON").Error(), nil)
+		return jsonrpc.Error(types.ErrCodeUnexpectedArgType,
+			rpc.ErrMethodArgType("JSON").Error(), nil)
 	}
 	// set the type to TxTypeBalance.
 	// it will override the type given

--- a/node/block.go
+++ b/node/block.go
@@ -72,7 +72,7 @@ func (g *Gossip) RelayBlock(block core.Block,
 			continue
 		}
 
-		g.PM().UpdatePeerTime(peer)
+		g.PM().UpdateLastSeen(peer)
 		g.engine.history.AddMulti(cache.Sec(600), historyKey...)
 
 		sent++
@@ -99,7 +99,7 @@ func (g *Gossip) OnBlockBody(s net.Stream) {
 		return
 	}
 
-	g.PM().UpdatePeerTime(remotePeer)
+	g.PM().UpdateLastSeen(remotePeer)
 
 	var block objects.Block
 	copier.Copy(&block, blockBody)
@@ -163,7 +163,7 @@ func (g *Gossip) RequestBlock(remotePeer types.Engine,
 		return err
 	}
 
-	g.PM().UpdatePeerTime(remotePeer)
+	g.PM().UpdateLastSeen(remotePeer)
 	g.engine.history.AddMulti(cache.Sec(600), historyKey...)
 
 	return nil
@@ -185,7 +185,7 @@ func (g *Gossip) OnRequestBlock(s net.Stream) {
 		return
 	}
 
-	g.PM().UpdatePeerTime(remotePeer)
+	g.PM().UpdateLastSeen(remotePeer)
 	g.log.Debug("Received request for block",
 		"RequestedBlockHash", util.StrToHash(requestBlock.Hash).SS())
 
@@ -345,7 +345,7 @@ func (g *Gossip) SendGetBlockHashes(remotePeer types.Engine,
 		return fmt.Errorf("%s: %s", errMsg, err)
 	}
 
-	g.PM().UpdatePeerTime(remotePeer)
+	g.PM().UpdateLastSeen(remotePeer)
 
 	// add all the hashes to the hash queue
 	for _, h := range blockHashes.Hashes {
@@ -387,7 +387,7 @@ func (g *Gossip) OnGetBlockHashes(s net.Stream) {
 		return
 	}
 
-	g.PM().UpdatePeerTime(remotePeer)
+	g.PM().UpdateLastSeen(remotePeer)
 
 	var blockHashes = wire.BlockHashes{}
 	var startBlock core.Block
@@ -497,7 +497,7 @@ func (g *Gossip) SendGetBlockBodies(remotePeer types.Engine,
 			"Failed to read stream: %s", err)
 	}
 
-	g.PM().UpdatePeerTime(remotePeer)
+	g.PM().UpdateLastSeen(remotePeer)
 	g.log.Info("Received block bodies",
 		"NumBlocks", len(blockBodies.Blocks))
 
@@ -553,7 +553,7 @@ func (g *Gossip) OnGetBlockBodies(s net.Stream) {
 		return
 	}
 
-	g.PM().UpdatePeerTime(remotePeer)
+	g.PM().UpdateLastSeen(remotePeer)
 
 	var bestChain = g.GetBlockchain().ChainReader()
 	var blockBodies = new(wire.BlockBodies)

--- a/node/block.go
+++ b/node/block.go
@@ -1,9 +1,7 @@
 package node
 
 import (
-	"context"
 	"fmt"
-	"time"
 
 	"github.com/ellcrys/elld/types/core/objects"
 	"github.com/ellcrys/elld/util/cache"
@@ -29,55 +27,59 @@ func makeBlockHistoryKey(hash string, peer types.Engine) []interface{} {
 	return []interface{}{"b", hash, peer.StringID()}
 }
 
-func makeOrphanBlockHistoryKey(blockHash util.Hash, peer types.Engine) []interface{} {
+func makeOrphanBlockHistoryKey(blockHash util.Hash,
+	peer types.Engine) []interface{} {
 	return []interface{}{"ob", blockHash.HexStr(), peer.StringID()}
 }
 
-// RelayBlock sends a given block to remote peers
-// wrapped as the only block in a BlockBodies
-func (g *Gossip) RelayBlock(block core.Block, remotePeers []types.Engine) error {
+// RelayBlock sends a given block
+// to remote peers wrapped as the
+// only block in a BlockBodies
+func (g *Gossip) RelayBlock(block core.Block,
+	remotePeers []types.Engine) error {
 
-	g.log.Debug("Relaying block to peer(s)", "BlockNo", block.GetNumber(), "NumPeers", len(remotePeers))
+	g.log.Debug("Relaying block to peer(s)", "BlockNo", block.GetNumber(),
+		"NumPeers", len(remotePeers))
 
 	sent := 0
-
 	for _, peer := range remotePeers {
 
 		historyKey := makeBlockHistoryKey(block.HashToHex(), peer)
 
-		// check if we have an history of sending or receiving this block
-		// from this remote peer. If yes, do not relay
+		// check if we have an history of
+		// sending or receiving this block
+		// from this remote peer.
+		// If yes, do not relay
 		if g.engine.history.HasMulti(historyKey...) {
 			continue
 		}
 
-		// create a stream to the remote peer
-		ctxDur := time.Second * time.Duration(g.engine.cfg.Node.MessageTimeout)
-		ctx, cf := context.WithTimeout(context.TODO(), ctxDur)
-		defer cf()
-		s, err := g.NewStream(ctx, peer, config.BlockBodyVersion)
+		s, c, err := g.NewStream(peer, config.BlockBodyVersion)
 		if err != nil {
-			g.log.Error("Block message failed. failed to connect to peer", "Err", err, "PeerID", peer.ShortID())
+			g.log.Error("Block message failed. failed to connect to peer",
+				"Err", err, "PeerID", peer.ShortID())
 			continue
 		}
+		defer c()
 		defer s.Close()
 
-		// write to the stream
 		var blockBody wire.BlockBody
 		copier.Copy(&blockBody, block)
 		if err := WriteStream(s, blockBody); err != nil {
 			s.Reset()
-			g.log.Error("Block message failed. failed to write to stream", "Err", err, "PeerID", peer.ShortID())
+			g.log.Error("Block message failed. failed to write to stream",
+				"Err", err, "PeerID", peer.ShortID())
 			continue
 		}
 
-		// add new history
+		g.PM().UpdatePeerTime(peer)
 		g.engine.history.AddMulti(cache.Sec(600), historyKey...)
 
 		sent++
 	}
 
-	g.log.Info("Finished relaying block", "BlockNo", block.GetNumber(), "NumPeersSentTo", sent)
+	g.log.Info("Finished relaying block", "BlockNo",
+		block.GetNumber(), "NumPeersSentTo", sent)
 
 	return nil
 }
@@ -86,77 +88,82 @@ func (g *Gossip) RelayBlock(block core.Block, remotePeers []types.Engine) error 
 func (g *Gossip) OnBlockBody(s net.Stream) {
 
 	defer s.Close()
-	remotePeer := NewRemoteNode(util.FullRemoteAddressFromStream(s), g.engine)
+	remotePeer := NewRemoteNode(util.RemoteAddressFromStream(s), g.engine)
 	rpID := remotePeer.ShortID()
 
-	// read the message
 	blockBody := &wire.BlockBody{}
 	if err := ReadStream(s, &blockBody); err != nil {
 		s.Reset()
-		g.log.Error("Failed to read block message", "Err", err, "PeerID", rpID)
+		g.log.Error("Failed to read block message",
+			"Err", err, "PeerID", rpID)
 		return
 	}
+
+	g.PM().UpdatePeerTime(remotePeer)
 
 	var block objects.Block
 	copier.Copy(&block, blockBody)
 	block.SetBroadcaster(remotePeer)
 
-	g.log.Info("Received a block", "BlockNo", block.GetNumber(), "Difficulty", block.GetHeader().GetDifficulty())
+	g.log.Info("Received a block",
+		"BlockNo", block.GetNumber(),
+		"Difficulty", block.GetHeader().GetDifficulty())
 
-	// make a key for this block to be added to the history cache
-	// so we always know when we have sent/receive this block from/to
-	// the remote peer
+	// check if we have an history about this
+	// block with the remote peer, if no,
+	// process the block.
 	historyKey := makeBlockHistoryKey(block.HashToHex(), remotePeer)
-
-	// check if we have an history about this block
-	// with the remote peer, if no, process the block.
-	if !g.engine.history.HasMulti(historyKey...) {
-
-		// Add the transaction to the transaction pool and wait for error response
-		if _, err := g.GetBlockchain().ProcessBlock(&block); err != nil {
-			g.engine.event.Emit(EventBlockProcessed, &block, err)
-			return
-		}
-
-		g.engine.event.Emit(EventBlockProcessed, &block, nil)
-
-		// add transaction to the history cache using the key we created earlier
-		g.engine.history.AddMulti(cache.Sec(600), historyKey...)
+	if g.engine.history.HasMulti(historyKey...) {
+		return
 	}
+
+	// Add the transaction to the transaction
+	// pool and wait for error response
+	if _, err := g.GetBlockchain().ProcessBlock(&block); err != nil {
+		g.engine.event.Emit(EventBlockProcessed, &block, err)
+		return
+	}
+
+	g.engine.event.Emit(EventBlockProcessed, &block, nil)
+
+	// add transaction to the history cache
+	// using the key we created earlier
+	g.engine.history.AddMulti(cache.Sec(600), historyKey...)
 }
 
-// RequestBlock sends a RequestBlock message to remotePeer
-func (g *Gossip) RequestBlock(remotePeer types.Engine, blockHash util.Hash) error {
+// RequestBlock sends a RequestBlock
+// message to remotePeer
+func (g *Gossip) RequestBlock(remotePeer types.Engine,
+	blockHash util.Hash) error {
 
 	historyKey := makeOrphanBlockHistoryKey(blockHash, remotePeer)
 
-	// check if we have an history of sending or receiving this request
-	// from this remote peer. If yes, do not relay
+	// check if we have an history of sending
+	// or receiving this request from this
+	// remote peer. If yes, do not relay
 	if g.engine.history.HasMulti(historyKey...) {
 		return nil
 	}
 
-	// create a stream to the remote peer
-	ctxDur := time.Second * time.Duration(g.engine.cfg.Node.MessageTimeout)
-	ctx, cf := context.WithTimeout(context.TODO(), ctxDur)
-	defer cf()
-	s, err := g.NewStream(ctx, remotePeer, config.RequestBlockVersion)
+	s, c, err := g.NewStream(remotePeer, config.RequestBlockVersion)
 	if err != nil {
-		g.log.Error("RequestBlock message failed. failed to connect to peer", "Err", err, "PeerID", remotePeer.ShortID())
+		g.log.Error("RequestBlock message failed. failed to connect to peer",
+			"Err", err, "PeerID", remotePeer.ShortID())
 		return err
 	}
+	defer c()
 	defer s.Close()
 
-	// write to the stream
 	if err := WriteStream(s, &wire.RequestBlock{
 		Hash: blockHash.HexStr(),
 	}); err != nil {
 		s.Reset()
-		g.log.Error("RequestBlock message failed. failed to write to stream", "Err", err, "PeerID", remotePeer.ShortID())
+		g.log.Error("RequestBlock message failed. failed to write to stream",
+			"Err", err, "PeerID", remotePeer.ShortID())
 		return err
 	}
 
-	// add new history
+	g.PM().UpdatePeerTime(remotePeer)
 	g.engine.history.AddMulti(cache.Sec(600), historyKey...)
 
 	return nil
@@ -166,31 +173,37 @@ func (g *Gossip) RequestBlock(remotePeer types.Engine, blockHash util.Hash) erro
 func (g *Gossip) OnRequestBlock(s net.Stream) {
 
 	defer s.Close()
-	remotePeer := NewRemoteNode(util.FullRemoteAddressFromStream(s), g.engine)
+	remotePeer := NewRemoteNode(util.RemoteAddressFromStream(s), g.engine)
 	rpID := remotePeer.ShortID()
 
 	// read the message
 	requestBlock := &wire.RequestBlock{}
 	if err := ReadStream(s, requestBlock); err != nil {
 		s.Reset()
-		g.log.Error("Failed to read requestblock message", "Err", err, "PeerID", rpID)
+		g.log.Error("Failed to read requestblock message",
+			"Err", err, "PeerID", rpID)
 		return
 	}
 
-	g.log.Debug("Received request for block", "RequestedBlockHash", util.StrToHash(requestBlock.Hash).SS())
+	g.PM().UpdatePeerTime(remotePeer)
+	g.log.Debug("Received request for block",
+		"RequestedBlockHash", util.StrToHash(requestBlock.Hash).SS())
 
-	// If the hash and number fields are not set,
-	// do not proceed and log error
+	// If the hash and number fields
+	// are not set, do not proceed
+	// and log error
 	if requestBlock.Hash == "" && requestBlock.Number == 0 {
 		s.Reset()
-		g.log.Warn("Invalid requestblock message: Empty 'Hash' and 'Number' fields", "PeerID", rpID)
+		g.log.Warn("Invalid requestblock message: "+
+			"Empty 'Hash' and 'Number' fields", "PeerID", rpID)
 		return
 	}
 
 	// The hash field is mandatory
 	if requestBlock.Hash == "" {
 		s.Reset()
-		g.log.Warn("Invalid requestblock message: Empty 'Hash'", "PeerID", rpID)
+		g.log.Warn("Invalid requestblock message: "+
+			"Empty 'Hash'", "PeerID", rpID)
 		return
 	}
 
@@ -201,36 +214,45 @@ func (g *Gossip) OnRequestBlock(s net.Stream) {
 		blockHash, err := util.HexToHash(requestBlock.Hash)
 		if err != nil {
 			s.Reset()
-			g.log.Warn("Invalid hash supplied in requestblock message",
-				"PeerID", rpID, "Hash", util.StrToHash(requestBlock.Hash).SS())
+			g.log.Warn("Invalid hash supplied in "+
+				"requestblock message",
+				"PeerID", rpID, "Hash",
+				util.StrToHash(requestBlock.Hash).SS())
 			return
 		}
 
 		// find the block by number and hash
-		block, err = g.GetBlockchain().GetBlock(requestBlock.Number, blockHash)
+		block, err = g.GetBlockchain().GetBlock(requestBlock.Number,
+			blockHash)
 		if err != nil {
 			if err != core.ErrBlockNotFound {
 				s.Reset()
-				g.log.Warn("Failed to find block described in requestblock message",
-					"PeerID", rpID, "Hash", util.StrToHash(requestBlock.Hash).SS())
+				g.log.Warn("Failed to find block described "+
+					"in requestblock message",
+					"PeerID", rpID,
+					"Hash", util.StrToHash(requestBlock.Hash).SS())
 				return
 			}
 			s.Reset()
 			g.log.Debug("Block is currently unknown",
-				"PeerID", rpID, "Hash", util.StrToHash(requestBlock.Hash).SS())
+				"PeerID", rpID,
+				"Hash", util.StrToHash(requestBlock.Hash).SS())
 			return
 		}
 	}
 
-	// If a block number is not provided, then we need to
-	// find the block by just the hash
+	// If a block number is not provided,
+	// then we need to find the block by
+	// just the hash
 	if requestBlock.Number == 0 {
 
 		// decode the hex into a util.Hash
 		blockHash, err := util.HexToHash(requestBlock.Hash)
 		if err != nil {
 			s.Reset()
-			g.log.Warn("Invalid hash supplied in requestblock message", "PeerID", rpID, "Hash", requestBlock.Hash)
+			g.log.Debug("Invalid hash supplied in "+
+				"requestblock message",
+				"PeerID", rpID, "Hash", requestBlock.Hash)
 			return
 		}
 
@@ -239,12 +261,15 @@ func (g *Gossip) OnRequestBlock(s net.Stream) {
 		if err != nil {
 			if err != core.ErrBlockNotFound {
 				s.Reset()
-				g.log.Warn("Failed to find block described in requestblock message", "PeerID", rpID, "Hash", requestBlock.Hash)
+				g.log.Debug("Failed to find block described "+
+					"in requestblock message",
+					"PeerID", rpID, "Hash", requestBlock.Hash)
 				return
 			}
 			s.Reset()
 			g.log.Debug("Block is currently unknown",
-				"PeerID", rpID, "Hash", util.StrToHash(requestBlock.Hash).SS())
+				"PeerID", rpID,
+				"Hash", util.StrToHash(requestBlock.Hash).SS())
 			return
 		}
 	}
@@ -252,7 +277,10 @@ func (g *Gossip) OnRequestBlock(s net.Stream) {
 	// relay the block to only the remote peer
 	if err := g.RelayBlock(block, []types.Engine{remotePeer}); err != nil {
 		s.Reset()
-		g.log.Error("Failed to relay block requested in requestblock message", "PeerID", rpID, "Hash", requestBlock.Hash)
+		g.log.Error("Failed to relay block requested "+
+			"in requestblock message",
+			"PeerID", rpID,
+			"Hash", requestBlock.Hash)
 		return
 	}
 }
@@ -267,19 +295,19 @@ func (g *Gossip) OnRequestBlock(s net.Stream) {
 //
 // If the locators is not provided via the locator argument,
 // they will be collected from the main chain.
-func (g *Gossip) SendGetBlockHashes(remotePeer types.Engine, locators []util.Hash) error {
+func (g *Gossip) SendGetBlockHashes(remotePeer types.Engine,
+	locators []util.Hash) error {
 
 	rpID := remotePeer.ShortID()
 	g.log.Debug("Requesting block headers", "PeerID", rpID)
 
-	ctxDur := time.Second * time.Duration(g.engine.cfg.Node.MessageTimeout)
-	ctx, cf := context.WithTimeout(context.TODO(), ctxDur)
-	defer cf()
-	s, err := g.NewStream(ctx, remotePeer, config.GetBlockHashesVersion)
+	s, c, err := g.NewStream(remotePeer, config.GetBlockHashesVersion)
 	if err != nil {
-		g.log.Error("GetBlockHashes message failed. Failed to connect to peer", "Err", err, "PeerID", rpID)
+		g.log.Error("GetBlockHashes message failed. Failed "+
+			"to connect to peer", "Err", err, "PeerID", rpID)
 		return err
 	}
+	defer c()
 	defer s.Close()
 
 	g.engine.setSyncing(true)
@@ -287,7 +315,8 @@ func (g *Gossip) SendGetBlockHashes(remotePeer types.Engine, locators []util.Has
 	if len(locators) == 0 {
 		locators, err = g.GetBlockchain().GetLocators()
 		if err != nil {
-			g.log.Error("GetBlockHashes message failed. Failed to gather locators", "Err", err)
+			g.log.Error("GetBlockHashes message failed. "+
+				"Failed to gather locators", "Err", err)
 			return err
 		}
 	}
@@ -298,20 +327,25 @@ func (g *Gossip) SendGetBlockHashes(remotePeer types.Engine, locators []util.Has
 	}
 
 	if err := WriteStream(s, msg); err != nil {
-		errMsg := fmt.Errorf("GetBlockHashes message failed. Failed to write to stream")
+		errMsg := fmt.Errorf("GetBlockHashes message failed. " +
+			"Failed to write to stream")
 		g.log.Error(errMsg.Error(), "Err", err, "PeerID", rpID)
 		return fmt.Errorf("%s: %s", errMsg, err)
 	}
 
-	g.engine.event.Emit(EventRequestedBlockHashes, msg.Locators, msg.MaxBlocks)
+	g.engine.event.Emit(EventRequestedBlockHashes,
+		msg.Locators, msg.MaxBlocks)
 
 	// Read the return block hashes
 	var blockHashes wire.BlockHashes
 	if err := ReadStream(s, &blockHashes); err != nil {
-		errMsg := fmt.Errorf("GetBlockHashes message failed. Failed to read stream")
+		errMsg := fmt.Errorf("GetBlockHashes message failed. " +
+			"Failed to read stream")
 		g.log.Error(errMsg.Error(), "Err", err, "PeerID", rpID)
 		return fmt.Errorf("%s: %s", errMsg, err)
 	}
+
+	g.PM().UpdatePeerTime(remotePeer)
 
 	// add all the hashes to the hash queue
 	for _, h := range blockHashes.Hashes {
@@ -322,7 +356,8 @@ func (g *Gossip) SendGetBlockHashes(remotePeer types.Engine, locators []util.Has
 	}
 
 	g.engine.event.Emit(EventReceivedBlockHashes)
-	g.log.Info("Successfully requested block headers", "PeerID", rpID, "NumLocators", len(msg.Locators))
+	g.log.Info("Successfully requested block headers",
+		"PeerID", rpID, "NumLocators", len(msg.Locators))
 
 	return nil
 }
@@ -341,15 +376,18 @@ func (g *Gossip) SendGetBlockHashes(remotePeer types.Engine, locators []util.Has
 // ancestor) which exists on the main chain.
 func (g *Gossip) OnGetBlockHashes(s net.Stream) {
 	defer s.Close()
-	remotePeer := NewRemoteNode(util.FullRemoteAddressFromStream(s), g.engine)
+	remotePeer := NewRemoteNode(util.RemoteAddressFromStream(s), g.engine)
 	rpID := remotePeer.ShortID()
 
 	// Read the message
 	msg := &wire.GetBlockHashes{}
 	if err := ReadStream(s, msg); err != nil {
-		g.log.Error("Failed to read block message", "Err", err, "PeerID", rpID)
+		g.log.Error("Failed to read block message",
+			"Err", err, "PeerID", rpID)
 		return
 	}
+
+	g.PM().UpdatePeerTime(remotePeer)
 
 	var blockHashes = wire.BlockHashes{}
 	var startBlock core.Block
@@ -383,7 +421,8 @@ func (g *Gossip) OnGetBlockHashes(s net.Stream) {
 	// parent block from which the chain (and its parent)
 	// sprouted from. Otherwise, get the locator block
 	// and use as the start block.
-	if mainChain := g.GetBlockchain().GetBestChain(); mainChain.GetID() != locatorChain.GetID() {
+	if mainChain := g.GetBlockchain().GetBestChain(); mainChain.GetID() !=
+		locatorChain.GetID() {
 		startBlock = locatorChain.GetRoot()
 	} else {
 		startBlock, _ = locatorChain.GetBlockByHash(locatorHash)
@@ -414,20 +453,22 @@ send:
 
 // SendGetBlockBodies sends a GetBlockBodies message
 // requesting for whole bodies of a collection blocks.
-func (g *Gossip) SendGetBlockBodies(remotePeer types.Engine, hashes []util.Hash) error {
+func (g *Gossip) SendGetBlockBodies(remotePeer types.Engine,
+	hashes []util.Hash) error {
 
 	rpID := remotePeer.ShortID()
-	g.log.Debug("Requesting block bodies", "PeerID", rpID, "NumHashes", len(hashes))
+	g.log.Debug("Requesting block bodies",
+		"PeerID", rpID,
+		"NumHashes", len(hashes))
 
-	// create a stream to the remote peer
-	ctxDur := time.Second * time.Duration(g.engine.cfg.Node.MessageTimeout)
-	ctx, cf := context.WithTimeout(context.TODO(), ctxDur)
-	defer cf()
-	s, err := g.NewStream(ctx, remotePeer, config.GetBlockBodiesVersion)
+	s, c, err := g.NewStream(remotePeer, config.GetBlockBodiesVersion)
 	if err != nil {
-		g.log.Error("GetBlockBodies message failed. Failed to connect to peer", "Err", err, "PeerID", rpID)
-		return fmt.Errorf("GetBlockBodies message failed. Failed to connect to peer: %s", err)
+		g.log.Error("GetBlockBodies message failed. "+
+			"Failed to connect to peer", "Err", err, "PeerID", rpID)
+		return fmt.Errorf("GetBlockBodies message failed. "+
+			"Failed to connect to peer: %s", err)
 	}
+	defer c()
 	defer s.Close()
 
 	// do nothing if no hash is given
@@ -441,18 +482,24 @@ func (g *Gossip) SendGetBlockBodies(remotePeer types.Engine, hashes []util.Hash)
 
 	// write to the stream
 	if err := WriteStream(s, msg); err != nil {
-		g.log.Error("GetBlockBodies message failed. Failed to write to stream", "Err", err, "PeerID", rpID)
-		return fmt.Errorf("GetBlockBodies message failed. Failed to write to stream: %s", err)
+		g.log.Error("GetBlockBodies message failed. "+
+			"Failed to write to stream", "Err", err, "PeerID", rpID)
+		return fmt.Errorf("GetBlockBodies message failed. "+
+			"Failed to write to stream: %s", err)
 	}
 
 	// Read the return block bodies
 	var blockBodies wire.BlockBodies
 	if err := ReadStream(s, &blockBodies); err != nil {
-		g.log.Error("Unable to retrieve BlockBodies. Failed to read stream", "Err", err, "PeerID", rpID)
-		return fmt.Errorf("Unable to retrieve BlockBodies. Failed to read stream: %s", err)
+		g.log.Error("Unable to retrieve BlockBodies. "+
+			"Failed to read stream", "Err", err, "PeerID", rpID)
+		return fmt.Errorf("Unable to retrieve BlockBodies. "+
+			"Failed to read stream: %s", err)
 	}
 
-	g.log.Info("Received block bodies", "NumBlocks", len(blockBodies.Blocks))
+	g.PM().UpdatePeerTime(remotePeer)
+	g.log.Info("Received block bodies",
+		"NumBlocks", len(blockBodies.Blocks))
 
 	// attempt to append the blocks to the blockchain
 	for _, bb := range blockBodies.Blocks {
@@ -496,7 +543,7 @@ func (g *Gossip) SendGetBlockBodies(remotePeer types.Engine, hashes []util.Hash)
 
 // OnGetBlockBodies handles GetBlockBodies requests
 func (g *Gossip) OnGetBlockBodies(s net.Stream) {
-	remotePeer := NewRemoteNode(util.FullRemoteAddressFromStream(s), g.engine)
+	remotePeer := NewRemoteNode(util.RemoteAddressFromStream(s), g.engine)
 	rpID := remotePeer.ShortID()
 
 	// Read the message
@@ -506,13 +553,16 @@ func (g *Gossip) OnGetBlockBodies(s net.Stream) {
 		return
 	}
 
+	g.PM().UpdatePeerTime(remotePeer)
+
 	var bestChain = g.GetBlockchain().ChainReader()
 	var blockBodies = new(wire.BlockBodies)
 	for _, hash := range msg.Hashes {
 		block, err := bestChain.GetBlockByHash(hash)
 		if err != nil {
 			if err != core.ErrBlockNotFound {
-				g.log.Error("Failed fetch block body of a given hash", "Err", err, "Hash", hash)
+				g.log.Error("Failed fetch block body of a given hash",
+					"Err", err, "Hash", hash)
 				return
 			}
 			continue

--- a/node/connection_mgr.go
+++ b/node/connection_mgr.go
@@ -52,15 +52,17 @@ func (m *ConnectionManager) needMoreConnections() bool {
 // addresses that have not been connected to as long as the max
 // connection limit has not been reached
 func (m *ConnectionManager) makeConnections(done chan bool) {
-	ticker := time.NewTicker(time.Duration(m.pm.config.Node.ConnEstInterval) * time.Second)
+	dur := time.Duration(m.pm.config.Node.ConnEstInterval)
+	ticker := time.NewTicker(dur * time.Second)
 	for {
 		select {
 		case <-ticker.C:
 			unconnectedPeers := m.pm.GetUnconnectedPeers()
-			if !m.pm.NeedMorePeers() || len(unconnectedPeers) == 0 {
+			if !m.pm.RequirePeers() || len(unconnectedPeers) == 0 {
 				continue
 			}
-			m.log.Info("Establishing connection with more peers", "UnconnectedPeers", len(unconnectedPeers))
+			m.log.Info("Establishing connection with more peers",
+				"UnconnectedPeers", len(unconnectedPeers))
 			for _, p := range unconnectedPeers {
 				m.pm.ConnectToPeer(p.StringID())
 			}

--- a/node/getaddr.go
+++ b/node/getaddr.go
@@ -55,7 +55,7 @@ func (g *Gossip) SendGetAddr(remotePeers []types.Engine) error {
 
 	// we need to know if wee need more peers before we requests
 	// more addresses from other peers.
-	if !g.PM().NeedMorePeers() {
+	if !g.PM().RequirePeers() {
 		return nil
 	}
 

--- a/node/getaddr.go
+++ b/node/getaddr.go
@@ -35,7 +35,7 @@ func (g *Gossip) SendGetAddrToPeer(remotePeer types.Engine) ([]*wire.Address, er
 		return nil, fmt.Errorf("getaddr failed. failed to write to stream")
 	}
 
-	g.PM().UpdatePeerTime(remotePeer)
+	g.PM().UpdateLastSeen(remotePeer)
 	g.log.Debug("GetAddr message sent to peer", "PeerID", remotePeerIDShort)
 
 	addr, err := g.onAddr(s)
@@ -106,7 +106,7 @@ func (g *Gossip) OnGetAddr(s net.Stream) {
 		return
 	}
 
-	g.PM().UpdatePeerTime(remotePeer)
+	g.PM().UpdateLastSeen(remotePeer)
 	g.log.Debug("Received GetAddr message", "PeerID", remotePeerIDShort)
 
 	// get active addresses we know about. If we have more 2500
@@ -127,7 +127,7 @@ func (g *Gossip) OnGetAddr(s net.Stream) {
 		}
 		addr.Addresses = append(addr.Addresses, &wire.Address{
 			Address:   peer.GetMultiAddr(),
-			Timestamp: peer.GetTimestamp().Unix(),
+			Timestamp: peer.GetLastSeen().Unix(),
 		})
 	}
 

--- a/node/getaddr_test.go
+++ b/node/getaddr_test.go
@@ -67,7 +67,7 @@ var _ = Describe("GetAddr", func() {
 			BeforeEach(func() {
 				remoteAddr = makeTestNode(getPort())
 				remoteAddr.SetTimestamp(time.Now().Add(-3 * time.Hour))
-				err := rp.PM().AddOrUpdatePeer(remoteAddr)
+				err := rp.PM().UpdatePeerTime(remoteAddr)
 				Expect(err).To(BeNil())
 			})
 
@@ -85,7 +85,7 @@ var _ = Describe("GetAddr", func() {
 		Context("when a remote peer knowns an address that is the same as the requesting peer", func() {
 
 			BeforeEach(func() {
-				err := rp.PM().AddOrUpdatePeer(lp)
+				err := rp.PM().UpdatePeerTime(lp)
 				Expect(err).To(BeNil())
 			})
 
@@ -102,7 +102,7 @@ var _ = Describe("GetAddr", func() {
 			BeforeEach(func() {
 				remoteAddr = makeTestNode(getPort())
 				remoteAddr.SetTimestamp(time.Now())
-				err := rp.PM().AddOrUpdatePeer(remoteAddr)
+				err := rp.PM().UpdatePeerTime(remoteAddr)
 				Expect(err).To(BeNil())
 			})
 
@@ -125,7 +125,7 @@ var _ = Describe("GetAddr", func() {
 				remoteAddr = makeTestNode(getPort())
 				remoteAddr.MakeHardcoded()
 				remoteAddr.SetTimestamp(time.Now())
-				err := rp.PM().AddOrUpdatePeer(remoteAddr)
+				err := rp.PM().UpdatePeerTime(remoteAddr)
 				Expect(err).To(BeNil())
 			})
 
@@ -147,7 +147,7 @@ var _ = Describe("GetAddr", func() {
 				lp.GetCfg().Node.MaxAddrsExpected = 0
 				remoteAddr = makeTestNode(getPort())
 				remoteAddr.SetTimestamp(time.Now())
-				err := rp.PM().AddOrUpdatePeer(remoteAddr)
+				err := rp.PM().UpdatePeerTime(remoteAddr)
 				Expect(err).To(BeNil())
 			})
 

--- a/node/getaddr_test.go
+++ b/node/getaddr_test.go
@@ -66,8 +66,8 @@ var _ = Describe("GetAddr", func() {
 
 			BeforeEach(func() {
 				remoteAddr = makeTestNode(getPort())
-				remoteAddr.SetTimestamp(time.Now().Add(-3 * time.Hour))
-				err := rp.PM().UpdatePeerTime(remoteAddr)
+				remoteAddr.SetLastSeen(time.Now().Add(-3 * time.Hour))
+				err := rp.PM().UpdateLastSeen(remoteAddr)
 				Expect(err).To(BeNil())
 			})
 
@@ -85,7 +85,7 @@ var _ = Describe("GetAddr", func() {
 		Context("when a remote peer knowns an address that is the same as the requesting peer", func() {
 
 			BeforeEach(func() {
-				err := rp.PM().UpdatePeerTime(lp)
+				err := rp.PM().UpdateLastSeen(lp)
 				Expect(err).To(BeNil())
 			})
 
@@ -101,8 +101,8 @@ var _ = Describe("GetAddr", func() {
 
 			BeforeEach(func() {
 				remoteAddr = makeTestNode(getPort())
-				remoteAddr.SetTimestamp(time.Now())
-				err := rp.PM().UpdatePeerTime(remoteAddr)
+				remoteAddr.SetLastSeen(time.Now())
+				err := rp.PM().UpdateLastSeen(remoteAddr)
 				Expect(err).To(BeNil())
 			})
 
@@ -124,8 +124,8 @@ var _ = Describe("GetAddr", func() {
 			BeforeEach(func() {
 				remoteAddr = makeTestNode(getPort())
 				remoteAddr.MakeHardcoded()
-				remoteAddr.SetTimestamp(time.Now())
-				err := rp.PM().UpdatePeerTime(remoteAddr)
+				remoteAddr.SetLastSeen(time.Now())
+				err := rp.PM().UpdateLastSeen(remoteAddr)
 				Expect(err).To(BeNil())
 			})
 
@@ -146,8 +146,8 @@ var _ = Describe("GetAddr", func() {
 			BeforeEach(func() {
 				lp.GetCfg().Node.MaxAddrsExpected = 0
 				remoteAddr = makeTestNode(getPort())
-				remoteAddr.SetTimestamp(time.Now())
-				err := rp.PM().UpdatePeerTime(remoteAddr)
+				remoteAddr.SetLastSeen(time.Now())
+				err := rp.PM().UpdateLastSeen(remoteAddr)
 				Expect(err).To(BeNil())
 			})
 

--- a/node/handshake.go
+++ b/node/handshake.go
@@ -86,7 +86,7 @@ func (g *Gossip) SendHandshake(remotePeer types.Engine) error {
 	}
 
 	// Update the timestamp of the peer
-	g.PM().AddOrUpdatePeer(remotePeer)
+	g.PM().UpdatePeerTime(remotePeer)
 
 	// Set the remote peer's acquainted status to
 	// true, which will allow some unsolicited
@@ -169,7 +169,7 @@ func (g *Gossip) OnHandshake(s net.Stream) {
 
 	// update the remote peer's timestamp
 	// and add it to the peer manager's list
-	g.PM().AddOrUpdatePeer(remotePeer)
+	g.PM().UpdatePeerTime(remotePeer)
 
 	// Set the remote peer's acquainted status to
 	// true, which will allow some unsolicited

--- a/node/handshake.go
+++ b/node/handshake.go
@@ -83,7 +83,7 @@ func (g *Gossip) SendHandshake(remotePeer types.Engine) error {
 	}
 
 	// Update the timestamp of the peer
-	g.PM().UpdatePeerTime(remotePeer)
+	g.PM().UpdateLastSeen(remotePeer)
 
 	// Set the remote peer's acquainted status to
 	// true, which will allow some unsolicited
@@ -163,7 +163,7 @@ func (g *Gossip) OnHandshake(s net.Stream) {
 
 	// update the remote peer's timestamp
 	// and add it to the peer manager's list
-	g.PM().UpdatePeerTime(remotePeer)
+	g.PM().UpdateLastSeen(remotePeer)
 
 	// Set the remote peer's acquainted status to
 	// true, which will allow some unsolicited

--- a/node/node.go
+++ b/node/node.go
@@ -151,12 +151,14 @@ func newNode(db elldb.DB, config *config.EngineConfig, address string, coinbase 
 }
 
 // NewNode creates a Node instance
-func NewNode(config *config.EngineConfig, address string, signatory *d_crypto.Key, log logger.Logger) (*Node, error) {
+func NewNode(config *config.EngineConfig, address string,
+	signatory *d_crypto.Key, log logger.Logger) (*Node, error) {
 	return newNode(nil, config, address, signatory, log)
 }
 
 // NewNodeWithDB is like NewNode but it accepts a db instance
-func NewNodeWithDB(db elldb.DB, config *config.EngineConfig, address string, signatory *d_crypto.Key, log logger.Logger) (*Node, error) {
+func NewNodeWithDB(db elldb.DB, config *config.EngineConfig, address string,
+	signatory *d_crypto.Key, log logger.Logger) (*Node, error) {
 	return newNode(db, config, address, signatory, log)
 }
 
@@ -181,7 +183,9 @@ func NewAlmostEmptyNode() *Node {
 }
 
 // OpenDB opens the database.
-// In dev mode, create a namespace and open database file prefixed with the namespace.
+// In dev mode, create a namespace
+// and open database file prefixed
+// with the namespace.
 func (n *Node) OpenDB() error {
 
 	if n.db != nil {
@@ -239,7 +243,8 @@ func (n *Node) updateSyncInfo(bi *BestBlockInfo) {
 	// latest, we update to the latests
 	if n.bestRemoteBlockInfo == nil {
 		n.bestRemoteBlockInfo = bi
-	} else if n.bestRemoteBlockInfo.BestBlockTotalDifficulty.Cmp(bi.BestBlockTotalDifficulty) == -1 {
+	} else if n.bestRemoteBlockInfo.BestBlockTotalDifficulty.
+		Cmp(bi.BestBlockTotalDifficulty) == -1 {
 		n.bestRemoteBlockInfo = bi
 	}
 
@@ -258,7 +263,8 @@ compare:
 	// block is equal or better, we set syncing status
 	// to false
 	localBestBlock, _ := n.GetBlockchain().ChainReader().Current()
-	if localBestBlock.GetHeader().GetTotalDifficulty().Cmp(n.bestRemoteBlockInfo.BestBlockTotalDifficulty) > -1 {
+	if localBestBlock.GetHeader().GetTotalDifficulty().
+		Cmp(n.bestRemoteBlockInfo.BestBlockTotalDifficulty) > -1 {
 		n.syncing = false
 	}
 }
@@ -288,8 +294,10 @@ func (n *Node) getSyncStateInfo() *SyncStateInfo {
 
 	// compute progress percentage based
 	// on block height differences
-	pct := float64(100) * (float64(syncState.CurrentChainHeight) / float64(syncState.TargetChainHeight))
-	syncState.ProgressPercent, _ = decimal.NewFromFloat(pct).Round(1).Float64()
+	pct := float64(100) * (float64(syncState.CurrentChainHeight) /
+		float64(syncState.TargetChainHeight))
+	syncState.ProgressPercent, _ = decimal.NewFromFloat(pct).
+		Round(1).Float64()
 
 	return syncState
 }
@@ -312,8 +320,9 @@ func (n *Node) PM() *Manager {
 	return n.peerManager
 }
 
-// GetHistory return a cache for holding arbitrary
-// objects we want to keep track of
+// GetHistory return a cache for
+// holding arbitrary objects we
+// want to keep track of
 func (n *Node) GetHistory() *cache.Cache {
 	return n.history
 }
@@ -323,7 +332,8 @@ func (n *Node) IsSame(node types.Engine) bool {
 	return n.StringID() == node.StringID()
 }
 
-// GetBlockchain returns the blockchain manager
+// GetBlockchain returns the
+// blockchain manager
 func (n *Node) GetBlockchain() core.Blockchain {
 	return n.bchain
 }
@@ -333,12 +343,14 @@ func (n *Node) SetBlockchain(bchain core.Blockchain) {
 	n.bchain = bchain
 }
 
-// IsHardcodedSeed checks whether the node is an hardcoded seed node
+// IsHardcodedSeed checks whether
+// the node is an hardcoded seed node
 func (n *Node) IsHardcodedSeed() bool {
 	return n.isHardcodedSeed
 }
 
-// MakeHardcoded sets the node has an hardcoded seed node
+// MakeHardcoded sets the node has
+// an hardcoded seed node
 func (n *Node) MakeHardcoded() {
 	n.isHardcodedSeed = true
 }
@@ -350,7 +362,8 @@ func (n *Node) SetTimestamp(newTime time.Time) {
 	n.Timestamp = newTime
 }
 
-// GetEventEmitter gets the event emitter
+// GetEventEmitter gets the
+// event emitter
 func (n *Node) GetEventEmitter() *emitter.Emitter {
 	return n.event
 }
@@ -362,27 +375,33 @@ func (n *Node) GetTimestamp() time.Time {
 	return n.Timestamp
 }
 
-// DevMode checks whether the node is in dev mode
+// DevMode checks whether the
+// node is in dev mode
 func (n *Node) DevMode() bool {
 	return n.cfg.Node.Mode == config.ModeDev
 }
 
-// TestMode checks whether the node is in test mode
+// TestMode checks whether the
+// node is in test mode
 func (n *Node) TestMode() bool {
 	return n.cfg.Node.Mode == config.ModeTest
 }
 
-// ProdMode checks whether the node is in production mode
+// ProdMode checks whether the
+// node is in production mode
 func (n *Node) ProdMode() bool {
 	return n.cfg.Node.Mode == config.ModeProd
 }
 
-// IsSameID is like IsSame except it accepts string
+// IsSameID is like IsSame except
+// it accepts string
 func (n *Node) IsSameID(id string) bool {
 	return n.StringID() == id
 }
 
-// SetEventEmitter set the event bus used to broadcast events across the engine
+// SetEventEmitter set the event bus
+// used to broadcast events across
+// the engine
 func (n *Node) SetEventEmitter(ee *emitter.Emitter) {
 	n.event = ee
 	n.transactionsPool.SetEventEmitter(ee)
@@ -393,9 +412,11 @@ func (n *Node) SetLocalNode(node *Node) {
 	n.localNode = node
 }
 
-// canAcceptPeer determines whether we can continue to interact with
-// a remote node. This is a good place to check if a remote node
-// has been blacklisted etc
+// canAcceptPeer determines whether we
+// can continue to interact with a
+// remote node. This is a good place
+// to check if a remote node has been
+// blacklisted etc
 func (n *Node) canAcceptPeer(remotePeer *Node) (bool, error) {
 	// In non-production mode, we cannot interact with a remote peer with a public IP
 	if !n.ProdMode() && !util.IsDevAddr(remotePeer.IP) {
@@ -411,7 +432,8 @@ func (n *Node) canAcceptPeer(remotePeer *Node) (bool, error) {
 	return true, nil
 }
 
-// addToPeerStore adds a remote node to the host's peerstore
+// addToPeerStore adds a remote node
+// to the host's peerstore
 func (n *Node) addToPeerStore(remote types.Engine) *Node {
 	n.localNode.Peerstore().AddAddr(remote.ID(), remote.GetIP4TCPAddr(), pstore.PermanentAddrTTL)
 	return n
@@ -422,12 +444,14 @@ func (n *Node) newStream(ctx context.Context, peerID peer.ID, protocolID string)
 	return n.Host().NewStream(ctx, peerID, protocol.ID(protocolID))
 }
 
-// SetTransactionPool sets the transaction pool
+// SetTransactionPool sets the
+// transaction pool
 func (n *Node) SetTransactionPool(txp *txpool.TxPool) {
 	n.transactionsPool = txp
 }
 
-// SetGossipProtocol sets the gossip protocol implementation
+// SetGossipProtocol sets the
+// gossip protocol implementation
 func (n *Node) SetGossipProtocol(protoc *Gossip) {
 	n.gProtoc = protoc
 }
@@ -437,12 +461,14 @@ func (n *Node) GetHost() host.Host {
 	return n.host
 }
 
-// GetBlockHashQueue returns the block hash queue
+// GetBlockHashQueue returns
+// the block hash queue
 func (n *Node) GetBlockHashQueue() *lane.Deque {
 	return n.blockHashQueue
 }
 
-// Peerstore returns the Peerstore of the node
+// Peerstore returns the Peerstore
+// of the node
 func (n *Node) Peerstore() pstore.Peerstore {
 	if h := n.Host(); h != nil {
 		return h.Peerstore()
@@ -450,7 +476,8 @@ func (n *Node) Peerstore() pstore.Peerstore {
 	return nil
 }
 
-// Host returns the internal host instance
+// Host returns the internal
+// host instance
 func (n *Node) Host() host.Host {
 	return n.host
 }
@@ -466,7 +493,8 @@ func (n *Node) ID() peer.ID {
 	return id
 }
 
-// StringID is like ID() but returns string
+// StringID is like ID() but
+// it returns string
 func (n *Node) StringID() string {
 	if n.address == nil {
 		return ""
@@ -485,7 +513,8 @@ func (n *Node) ShortID() string {
 	return id[0:12] + ".." + id[40:52]
 }
 
-// Connected checks whether the node is connected to the local node.
+// Connected checks whether the node
+// is connected to the local node.
 // Returns false if node is the local node.
 func (n *Node) Connected() bool {
 	if n.localNode == nil {
@@ -494,7 +523,8 @@ func (n *Node) Connected() bool {
 	return len(n.localNode.host.Network().ConnsToPeer(n.ID())) > 0
 }
 
-// IsKnown checks whether a peer is known to the local node
+// IsKnown checks whether a peer is
+// known to the local node
 func (n *Node) IsKnown() bool {
 	if n.localNode == nil {
 		return false
@@ -512,8 +542,10 @@ func (n *Node) PubKey() crypto.PubKey {
 	return n.host.Peerstore().PubKey(n.host.ID())
 }
 
-// SetProtocolHandler sets the protocol handler for a specific protocol
-func (n *Node) SetProtocolHandler(version string, handler inet.StreamHandler) {
+// SetProtocolHandler sets the protocol
+// handler for a specific protocol
+func (n *Node) SetProtocolHandler(version string,
+	handler inet.StreamHandler) {
 	n.host.SetStreamHandler(protocol.ID(version), handler)
 }
 
@@ -524,19 +556,24 @@ func (n *Node) GetMultiAddr() string {
 	} else if n.remote {
 		return n.address.String()
 	}
-	hostAddr, _ := ma.NewMultiaddr(fmt.Sprintf("/ipfs/%s", n.host.ID().Pretty()))
+	hostAddr, _ := ma.NewMultiaddr(fmt.Sprintf("/ipfs/%s",
+		n.host.ID().Pretty()))
 	return n.host.Addrs()[0].Encapsulate(hostAddr).String()
 }
 
-// GetAddr returns the host and port of the node as "host:port"
+// GetAddr returns the host and port
+// of the node as "host:port"
 func (n *Node) GetAddr() string {
-	parts := strings.Split(strings.Trim(n.host.Addrs()[0].String(), "/"), "/")
+	hostAddr := n.host.Addrs()[0].String()
+	parts := strings.Split(strings.Trim(hostAddr, "/"), "/")
 	return fmt.Sprintf("%s:%s", parts[1], parts[3])
 }
 
-// GetIP4TCPAddr returns ip4 and tcp parts of the host's multi address
+// GetIP4TCPAddr returns ip4 and tcp
+// parts of the host's multi address
 func (n *Node) GetIP4TCPAddr() ma.Multiaddr {
-	ipfsAddr, _ := ma.NewMultiaddr(fmt.Sprintf("/ipfs/%s", n.ID().Pretty()))
+	ipfsPart := fmt.Sprintf("/ipfs/%s", n.ID().Pretty())
+	ipfsAddr, _ := ma.NewMultiaddr(ipfsPart)
 	return n.address.Decapsulate(ipfsAddr)
 }
 
@@ -545,8 +582,9 @@ func (n *Node) GetBindAddress() string {
 	return n.address.String()
 }
 
-// validateAddress checks whether an address is
-// valid for the current engine mode.
+// validateAddress checks whether
+// an address is valid for the
+// current engine mode.
 func validateAddress(engine types.Engine, address string) error {
 
 	// Check whether the address is valid
@@ -554,14 +592,18 @@ func validateAddress(engine types.Engine, address string) error {
 		return fmt.Errorf("not a valid multiaddr")
 	}
 
-	// In non-production mode, only local/private addresses are allowed
+	// In non-production mode, only
+	// local/private addresses are allowed
 	if !engine.ProdMode() && !util.IsDevAddr(util.GetIPFromAddr(address)) {
-		return fmt.Errorf("public addresses are not allowed in development mode")
+		return fmt.Errorf("public addresses are " +
+			"not allowed in development mode")
 	}
 
-	// In production mode, only routable addresses are allowed
+	// In production mode, only routable
+	// addresses are allowed
 	if engine.ProdMode() && !util.IsRoutableAddr(address) {
-		return fmt.Errorf("local or private addresses are not allowed in production mode")
+		return fmt.Errorf("local or private addresses " +
+			"are not allowed in production mode")
 	}
 
 	return nil
@@ -575,7 +617,8 @@ func (n *Node) AddAddresses(peerAddresses []string, hardcoded bool) error {
 	for _, addr := range peerAddresses {
 
 		if err := validateAddress(n, addr); err != nil {
-			n.log.Info("Invalid Bootstrap Address: "+err.Error(), "Address", addr)
+			n.log.Info("Invalid Bootstrap Address",
+				"Err", err.Error(), "Address", addr)
 			continue
 		}
 
@@ -588,8 +631,9 @@ func (n *Node) AddAddresses(peerAddresses []string, hardcoded bool) error {
 	return nil
 }
 
-// connectToNode handshake to each bootstrap peer.
-// Then send GetAddr message if handshake is successful
+// connectToNode handshake to each bootstrap
+// peer. Then send GetAddr message if
+// handshake is successful
 func (n *Node) connectToNode(remote types.Engine) error {
 	if n.gProtoc.SendHandshake(remote) == nil {
 		n.gProtoc.SendGetAddr([]types.Engine{remote})
@@ -597,7 +641,8 @@ func (n *Node) connectToNode(remote types.Engine) error {
 	return nil
 }
 
-// relayTx continuously relays transactions in the tx relay queue
+// relayTx continuously relays transactions
+// in the tx relay queue
 func (n *Node) relayTx() {
 	ticker := time.NewTicker(3 * time.Second)
 	for {
@@ -641,19 +686,22 @@ func (n *Node) Start() {
 		go n.connectToNode(node)
 	}
 
-	// Start the sub-routine that relays transactions
+	// Start the sub-routine that
+	// relays transactions
 	go n.relayTx()
 
 	// Handle incoming events
 	go n.handleEvents()
 
-	// start a block body requester workers
+	// start a block body requester
+	// workers
 	for i := 0; i < params.NumBlockBodiesRequesters; i++ {
 		go n.ProcessBlockHashes()
 	}
 }
 
-// relayBlock attempts to relay non-genesis a block to active peers.
+// relayBlock attempts to relay non-genesis
+//  a block to active peers.
 func (n *Node) relayBlock(block core.Block) {
 	if block.GetNumber() > 1 {
 		n.gProtoc.RelayBlock(block, n.peerManager.GetActivePeers(0))
@@ -674,7 +722,8 @@ func (n *Node) handleNewTransactionEvent() {
 		select {
 		case evt := <-n.event.Once(core.EventNewTransaction):
 			if !n.GetTxRelayQueue().Add(evt.Args[0].(core.Transaction)) {
-				n.log.Debug("Failed to add transaction to relay queue.", "Err", "Capacity reached")
+				n.log.Debug("Failed to add transaction to relay queue.",
+					"Err", "Capacity reached")
 			}
 		}
 	}
@@ -688,8 +737,9 @@ func (n *Node) handleOrphanBlockEvent() {
 			// peer who sent it to us (a.k.a broadcaster)
 			orphanBlock := evt.Args[0].(*objects.Block)
 			parentHash := orphanBlock.GetHeader().GetParentHash()
-			n.log.Debug("Requesting orphan parent block from broadcaster", "BlockNo",
-				orphanBlock.GetNumber(), "ParentBlockHash", parentHash.SS())
+			n.log.Debug("Requesting orphan parent block from broadcaster",
+				"BlockNo", orphanBlock.GetNumber(),
+				"ParentBlockHash", parentHash.SS())
 			n.gProtoc.RequestBlock(orphanBlock.Broadcaster, parentHash)
 		}
 	}
@@ -703,10 +753,13 @@ func (n *Node) handleAbortedMinerBlockEvent() {
 			// listens for aborted miner blocks and attempt
 			// to re-add the transactions to the pool.
 			abortedBlock := evt.Args[0].(*objects.Block)
-			n.log.Debug("Attempting to re-add transactions in aborted miner block", "NumTx", len(abortedBlock.Transactions))
+			n.log.Debug("Attempting to re-add transactions "+
+				"in aborted miner block",
+				"NumTx", len(abortedBlock.Transactions))
 			for _, tx := range abortedBlock.Transactions {
 				if err := n.addTransaction(tx); err != nil {
-					n.log.Debug("failed to re-add transaction", "Err", err.Error())
+					n.log.Debug("failed to re-add transaction",
+						"Err", err.Error())
 				}
 			}
 		}
@@ -742,15 +795,20 @@ func (n *Node) ProcessBlockHashes() {
 			var broadcaster types.Engine
 			otherBlockHashes := []interface{}{}
 
-			// Collect hash of headers sent by a particular broadcaster.
-			// Temporarily keep the others in a cache to be added back
+			// Collect hash of headers sent by a
+			// particular broadcaster. Temporarily
+			// keep the others in a cache to be added back
 			// in the queue when we have collected some hashes
-			for !n.blockHashQueue.Empty() && int64(len(hashes)) < params.MaxGetBlockBodiesHashes {
+			for !n.blockHashQueue.Empty() && int64(len(hashes)) <
+				params.MaxGetBlockBodiesHashes {
 				bh := n.blockHashQueue.Shift().(*BlockHash)
-				if broadcaster != nil && bh.Broadcaster.StringID() != broadcaster.StringID() {
+
+				if broadcaster != nil && bh.Broadcaster.StringID() !=
+					broadcaster.StringID() {
 					otherBlockHashes = append(otherBlockHashes, bh)
 					continue
 				}
+
 				hashes = append(hashes, bh.Hash)
 				broadcaster = bh.Broadcaster
 			}
@@ -805,8 +863,9 @@ func (n *Node) Stop() {
 	// Close the database.
 	if n.db != nil {
 
-		// Wait a few seconds for active operations to
-		// complete before closing the database
+		// Wait a few seconds for active
+		// operations to complete before
+		// closing the database
 		time.Sleep(2 * time.Second)
 
 		err := n.db.Close()
@@ -866,7 +925,8 @@ func (n *Node) IsBadTimestamp() bool {
 	}
 
 	now := time.Now().UTC()
-	if n.Timestamp.After(now.Add(time.Minute*10)) || n.Timestamp.Before(now.Add(-3*time.Hour)) {
+	if n.Timestamp.After(now.Add(time.Minute*10)) ||
+		n.Timestamp.Before(now.Add(-3*time.Hour)) {
 		return true
 	}
 

--- a/node/node.go
+++ b/node/node.go
@@ -583,7 +583,7 @@ func (n *Node) AddAddresses(peerAddresses []string, hardcoded bool) error {
 		rp := NewRemoteNode(pAddr, n)
 		rp.isHardcodedSeed = hardcoded
 		rp.gProtoc = n.gProtoc
-		n.peerManager.addPeer(rp)
+		n.peerManager.AddPeer(rp)
 	}
 	return nil
 }

--- a/node/node_unit_test.go
+++ b/node/node_unit_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/ellcrys/elld/testutil"
 	host "github.com/libp2p/go-libp2p-host"
 	pstore "github.com/libp2p/go-libp2p-peerstore"
-	ma "github.com/multiformats/go-multiaddr"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -161,24 +160,25 @@ var _ = Describe("Node Unit Test", func() {
 	Describe(".AddBootstrapNodes", func() {
 		Context("with empty address", func() {
 			It("peer manager's bootstrap list should be empty", func() {
-				n.AddBootstrapNodes(nil, false)
-				Expect(n.PM().GetBootstrapNodes()).To(HaveLen(0))
+				n.AddAddresses(nil, false)
+				Expect(n.PM().GetPeers()).To(HaveLen(0))
 			})
 		})
 
 		Context("with invalid address", func() {
 			It("peer manager's bootstrap list should not contain invalid address", func() {
-				n.AddBootstrapNodes([]string{"/ip4/127.0.0.1/tcp/40000"}, false)
-				Expect(n.PM().GetBootstrapNodes()).To(HaveLen(0))
+				n.AddAddresses([]string{"/ip4/127.0.0.1/tcp/40000"}, false)
+				Expect(n.PM().GetPeers()).To(HaveLen(0))
 			})
 
 			It("peer manager's bootstrap list contain only one valid address", func() {
-				n.AddBootstrapNodes([]string{
+				addresses := []string{
 					"/ip4/127.0.0.1/tcp/40000",
 					"/ip4/127.0.0.1/tcp/40000/ipfs/12D3KooWL3XJ9EMCyZvmmGXL2LMiVBtrVa2BuESsJiXkSj7333Jw",
-				}, false)
-				Expect(n.PM().GetBootstrapNodes()).To(HaveLen(1))
-				Expect(n.PM().GetBootstrapPeer("12D3KooWL3XJ9EMCyZvmmGXL2LMiVBtrVa2BuESsJiXkSj7333Jw")).To(BeAssignableToTypeOf(&node.Node{}))
+				}
+				n.AddAddresses(addresses, false)
+				Expect(n.PM().GetPeers()).To(HaveLen(1))
+				Expect(n.PM().GetPeer("12D3KooWL3XJ9EMCyZvmmGXL2LMiVBtrVa2BuESsJiXkSj7333Jw")).ToNot(BeNil())
 			})
 		})
 	})
@@ -205,22 +205,6 @@ var _ = Describe("Node Unit Test", func() {
 
 			host.Connect(context.Background(), host.Peerstore().PeerInfo(host2.ID()))
 			host.Connect(context.Background(), host.Peerstore().PeerInfo(host3.ID()))
-		})
-
-		It("the peers (/ip4/127.0.0.1/tcp/40106, /ip4/127.0.0.1/tcp/40107) must be returned", func() {
-			peers := n.PeersPublicAddr(nil)
-			Expect(peers).To(HaveLen(2))
-			expected, _ := ma.NewMultiaddr("/ip4/127.0.0.1/tcp/40106")
-			expected2, _ := ma.NewMultiaddr("/ip4/127.0.0.1/tcp/40107")
-			Expect(peers).To(ContainElement(expected))
-			Expect(peers).To(ContainElement(expected2))
-		})
-
-		It("only /ip4/127.0.0.1/tcp/40107 must be returned", func() {
-			peers := n.PeersPublicAddr([]string{host2.ID().Pretty()})
-			Expect(peers).To(HaveLen(1))
-			expected, _ := ma.NewMultiaddr("/ip4/127.0.0.1/tcp/40107")
-			Expect(peers).To(ContainElement(expected))
 		})
 
 		AfterEach(func() {

--- a/node/node_unit_test.go
+++ b/node/node_unit_test.go
@@ -53,13 +53,15 @@ var _ = Describe("Node Unit Test", func() {
 			})
 
 			It("return nil if address is ':40000'", func() {
-				_, err := node.NewNode(cfg, ":40000", crypto.NewKeyFromIntSeed(1), log)
+				n, err := node.NewNode(cfg, ":40000", crypto.NewKeyFromIntSeed(1), log)
 				Expect(err).To(BeNil())
+				closeNode(n)
 			})
 
 			It("return nil if address is '127.0.0.1:40000'", func() {
-				_, err := node.NewNode(cfg, "127.0.0.1:40000", crypto.NewKeyFromIntSeed(1), log)
+				n, err := node.NewNode(cfg, "127.0.0.1:40000", crypto.NewKeyFromIntSeed(1), log)
 				Expect(err).To(BeNil())
+				closeNode(n)
 			})
 		})
 	})
@@ -136,17 +138,17 @@ var _ = Describe("Node Unit Test", func() {
 
 	Describe(".IsBadTimestamp", func() {
 		It("should return false when time is zero", func() {
-			n.SetTimestamp(time.Time{})
+			n.SetLastSeen(time.Time{})
 			Expect(n.IsBadTimestamp()).To(BeTrue())
 		})
 
 		It("should return false when time 10 minutes, 1 second in the future", func() {
-			n.SetTimestamp(time.Now().Add(10*time.Minute + 1*time.Second))
+			n.SetLastSeen(time.Now().Add(10*time.Minute + 1*time.Second))
 			Expect(n.IsBadTimestamp()).To(BeTrue())
 		})
 
 		It("should return false when time 3 hours, 1 second in the past", func() {
-			n.SetTimestamp(time.Now().Add(-3 * time.Hour))
+			n.SetLastSeen(time.Now().Add(-3 * time.Hour))
 			Expect(n.IsBadTimestamp()).To(BeTrue())
 		})
 	})
@@ -211,36 +213,6 @@ var _ = Describe("Node Unit Test", func() {
 			host.Close()
 			host2.Close()
 			host3.Close()
-		})
-	})
-
-	Describe(".Connected", func() {
-
-		var n, n2 *node.Node
-		var err error
-
-		BeforeEach(func() {
-			n, err = node.NewNode(cfg, "127.0.0.1:40106", crypto.NewKeyFromIntSeed(6), log)
-			Expect(err).To(BeNil())
-			n2, err = node.NewNode(cfg, "127.0.0.1:40107", crypto.NewKeyFromIntSeed(7), log)
-			Expect(err).To(BeNil())
-			n2.SetLocalNode(n)
-		})
-
-		It("should return false when localPeer is nil", func() {
-			n.SetLocalNode(nil)
-			Expect(n.Connected()).To(BeFalse())
-		})
-
-		It("should return true when peer is connected", func() {
-			n.GetHost().Peerstore().AddAddr(n2.GetHost().ID(), n2.GetHost().Addrs()[0], pstore.PermanentAddrTTL)
-			n.GetHost().Connect(context.Background(), n.GetHost().Peerstore().PeerInfo(n2.GetHost().ID()))
-			Expect(n2.Connected()).To(BeTrue())
-		})
-
-		AfterEach(func() {
-			closeNode(n)
-			closeNode(n2)
 		})
 	})
 

--- a/node/peer_mgr.go
+++ b/node/peer_mgr.go
@@ -21,16 +21,14 @@ import (
 // It is responsible for initiating and managing peers
 // according to the current protocol and engine rules.
 type Manager struct {
-	knownPeerMtx   *sync.Mutex             // known peer mutex
-	mtx            *sync.Mutex             // general mutex
-	localNode      *Node                   // local node
-	bootstrapNodes map[string]types.Engine // bootstrap peers
-	knownPeers     map[string]types.Engine // peers known to the peer manager
-	log            logger.Logger           // manager's logger
-	config         *config.EngineConfig    // manager's configuration
-	connMgr        *ConnectionManager      // connection manager
-	tickersDone    chan bool
-	stop           bool // signifies the start of the manager
+	mtx         *sync.RWMutex           // general mutex
+	localNode   *Node                   // local node
+	peers       map[string]types.Engine // peers known to the peer manager
+	log         logger.Logger           // manager's logger
+	config      *config.EngineConfig    // manager's configuration
+	connMgr     *ConnectionManager      // connection manager
+	stop        bool                    // signifies the start of the manager
+	tickersDone chan bool
 }
 
 // NewManager creates an instance of the peer manager
@@ -41,23 +39,13 @@ func NewManager(cfg *config.EngineConfig, localPeer *Node, log logger.Logger) *M
 		cfg.Node = &config.PeerConfig{}
 	}
 
-	// Set hardcoded config in production mode
-	if localPeer.ProdMode() {
-		cfg.Node.GetAddrInterval = 30 * 60
-		cfg.Node.PingInterval = 30 * 60
-		cfg.Node.SelfAdvInterval = 24 * 60 * 60
-		cfg.Node.CleanUpInterval = 10 * 60
-	}
-
 	m := &Manager{
-		knownPeerMtx:   new(sync.Mutex),
-		mtx:            new(sync.Mutex),
-		localNode:      localPeer,
-		log:            log,
-		bootstrapNodes: make(map[string]types.Engine),
-		knownPeers:     make(map[string]types.Engine),
-		config:         cfg,
-		tickersDone:    make(chan bool),
+		mtx:         new(sync.RWMutex),
+		localNode:   localPeer,
+		log:         log,
+		peers:       make(map[string]types.Engine),
+		config:      cfg,
+		tickersDone: make(chan bool),
 	}
 
 	m.connMgr = NewConnMrg(m, log)
@@ -67,21 +55,22 @@ func NewManager(cfg *config.EngineConfig, localPeer *Node, log logger.Logger) *M
 
 // PeerExist checks whether a peer is a known peer
 func (m *Manager) PeerExist(peerID string) bool {
-	m.knownPeerMtx.Lock()
-	defer m.knownPeerMtx.Unlock()
-	_, exist := m.knownPeers[peerID]
+	m.mtx.RLock()
+	defer m.mtx.RUnlock()
+	_, exist := m.peers[peerID]
 	return exist
 }
 
-// GetKnownPeer returns a known peer
-func (m *Manager) GetKnownPeer(peerID string) types.Engine {
+// GetPeer returns a peer
+func (m *Manager) GetPeer(peerID string) types.Engine {
+	m.mtx.RLock()
+	defer m.mtx.RUnlock()
+
 	if !m.PeerExist(peerID) {
 		return nil
 	}
 
-	m.knownPeerMtx.Lock()
-	defer m.knownPeerMtx.Unlock()
-	peer, _ := m.knownPeers[peerID]
+	peer, _ := m.peers[peerID]
 	return peer
 }
 
@@ -94,33 +83,26 @@ func (m *Manager) GetKnownPeer(peerID string) types.Engine {
 // Eventually, it will be removed if it does not reconnect.
 func (m *Manager) OnPeerDisconnect(peerAddr ma.Multiaddr) {
 	peerID := util.IDFromAddr(peerAddr).Pretty()
-	peer := m.GetKnownPeer(peerID)
+	peer := m.GetPeer(peerID)
 	if peer == nil {
 		return
 	}
 	m.HasDisconnected(peer)
 	m.log.Info("Peer has disconnected", "PeerID", peer.ShortID())
-	m.CleanKnownPeers()
+	m.CleanPeers()
 }
 
-// AddBootstrapPeer adds a peer to the manager
-func (m *Manager) AddBootstrapPeer(peer *Node) {
-	m.bootstrapNodes[peer.StringID()] = peer
+// addPeer adds a peer
+func (m *Manager) addPeer(peer *Node) {
+	m.mtx.Lock()
+	defer m.mtx.Unlock()
+	m.peers[peer.StringID()] = peer
 }
 
-// GetBootstrapNodes returns the bootstrap peers
-func (m *Manager) GetBootstrapNodes() map[string]types.Engine {
-	return m.bootstrapNodes
-}
-
-// GetBootstrapPeer returns a peer in the boostrap peer list
-func (m *Manager) GetBootstrapPeer(id string) types.Engine {
-	return m.bootstrapNodes[id]
-}
-
-// ConnectToPeer attempts to connect to a peer
+// ConnectToPeer attempts to establish
+// a connection to a peer with the given id
 func (m *Manager) ConnectToPeer(peerID string) error {
-	peer := m.GetKnownPeer(peerID)
+	peer := m.GetPeer(peerID)
 	if peer == nil {
 		return fmt.Errorf("peer not found")
 	}
@@ -128,11 +110,10 @@ func (m *Manager) ConnectToPeer(peerID string) error {
 }
 
 // GetUnconnectedPeers returns the peers that
-// are not connected to the local peer.
-// Hardcoded bootstrap peers are not included.
+// are currently not connected to the local peer.
 func (m *Manager) GetUnconnectedPeers() (peers []types.Engine) {
 	for _, p := range m.GetActivePeers(0) {
-		if !p.IsHardcodedSeed() && !p.Connected() {
+		if !p.Connected() {
 			peers = append(peers, p)
 		}
 	}
@@ -180,7 +161,7 @@ func (m *Manager) periodicPingMsgs(done chan bool) {
 	for {
 		select {
 		case <-ticker.C:
-			m.localNode.gProtoc.SendPing(m.GetKnownPeers())
+			m.localNode.gProtoc.SendPing(m.GetPeers())
 		case <-done:
 			ticker.Stop()
 			return
@@ -196,13 +177,13 @@ func (m *Manager) periodicSelfAdvertisement(done chan bool) {
 		select {
 		case <-ticker.C:
 			connectedPeers := []types.Engine{}
-			for _, p := range m.GetKnownPeers() {
+			for _, p := range m.GetPeers() {
 				if p.Connected() {
 					connectedPeers = append(connectedPeers, p)
 				}
 			}
 			m.localNode.gProtoc.SelfAdvertise(connectedPeers)
-			m.CleanKnownPeers()
+			m.CleanPeers()
 		case <-done:
 			ticker.Stop()
 			return
@@ -217,8 +198,8 @@ func (m *Manager) periodicCleanUp(done chan bool) {
 	for {
 		select {
 		case <-ticker.C:
-			nCleaned := m.CleanKnownPeers()
-			m.log.Debug("Cleaned up old peers", "NumKnownPeers", len(m.knownPeers), "NumPeersCleaned", nCleaned)
+			nCleaned := m.CleanPeers()
+			m.log.Debug("Cleaned up old peers", "NumKnownPeers", len(m.peers), "NumPeersCleaned", nCleaned)
 		case <-done:
 			ticker.Stop()
 			return
@@ -226,28 +207,32 @@ func (m *Manager) periodicCleanUp(done chan bool) {
 	}
 }
 
-// AddOrUpdatePeer adds a peer to the list of known peers if it doesn't
-// exist. If the peer already exists:
-// - if the peer has been seen in the last 24 hours and its current
-// 	 timestamp is over 60 minutes old, then update the timestamp to 60 minutes ago.
-// - else if the peer has not been seen in the last 24 hours and its current timestamp is
-//	 over 24 hours, then update the timestamp to 24 hours ago.
+// AddOrUpdatePeer adds a peer to the
+// list of peers if it has not been
+// added. If it has, then the following
+// steps are taken:
+// - If the peer has been seen in the
+// 	 last 24 hours and its current
+// 	 timestamp is over 60 minutes old,
+//	 update the timestamp to 60 minutes ago.
+// - If the peer has not been seen in the last
+//	 24 hours and its current timestamp is
+//	 over 24 hours, then update the timestamp
+// 	 to 24 hours ago.
 // - else use whatever timestamp is returned
 // - clean old addresses
 func (m *Manager) AddOrUpdatePeer(p types.Engine) error {
 
-	defer m.CleanKnownPeers()
+	defer m.CleanPeers()
 
 	if p == nil {
 		return fmt.Errorf("nil received")
 	}
 
-	// Peer address must not be same as the local node
 	if p.IsSame(m.localNode) {
 		return fmt.Errorf("peer is the local peer")
 	}
 
-	// It must have a valid address
 	if !util.IsValidAddr(p.GetMultiAddr()) {
 		return fmt.Errorf("peer address is not valid")
 	}
@@ -258,78 +243,77 @@ func (m *Manager) AddOrUpdatePeer(p types.Engine) error {
 	}
 
 	// Save the known peers.
-	// don't do this in test environment (we will test savePeer alone)
+	// don't do this in test environment
+	// (we will test savePeer independently)
 	if !m.localNode.TestMode() {
 		defer m.SavePeers()
 	}
 
-	m.knownPeerMtx.Lock()
-	defer m.knownPeerMtx.Unlock()
+	m.mtx.Lock()
+	defer m.mtx.Unlock()
 
-	// update the timestamp only if not already
-	// set by caller or elsewhere
+	// Update the timestamp only if
+	// not already set by caller or elsewhere
 	if p.GetTimestamp().IsZero() {
-		p.SetTimestamp(time.Now())
+		p.SetTimestamp(time.Now().UTC())
 	}
 
-	// get a peer matching the ID from the list of known peers.
-	// if it does not exist, we add it immediately
-	existingPeer, exist := m.knownPeers[p.StringID()]
+	// Get a peer matching the ID from the
+	// list of peers. if it does not
+	// exist, we add it immediately
+	existingPeer, exist := m.peers[p.StringID()]
 	if !exist {
-		m.knownPeers[p.StringID()] = p
+		m.peers[p.StringID()] = p
 		return nil
 	}
 
-	// if a peer exists, return error if the peer's
-	// full address matches the candidate peer
+	// Since the peer exists, return error
+	// if the existing peer's full address
+	// matches the peer's full address
 	if existingPeer.GetMultiAddr() != p.GetMultiAddr() {
 		return fmt.Errorf("existing peer address do not match")
 	}
 
-	// If the candidate peer's timestamp is within
-	// the last 24 hours and the existing/matching peer we already know
-	// has a timestamp within the last hour, we set the existing peer's
-	// timestamp to an hour ago.
-	now := time.Now()
+	now := time.Now().UTC()
 	if now.Add(-24*time.Hour).Before(p.GetTimestamp()) && now.Add(-60*time.Minute).Before(existingPeer.GetTimestamp()) {
 		existingPeer.SetTimestamp(now.Add(-60 * time.Minute))
 		return nil
 	}
 
-	// If the candidate peer's timestamp is not within
-	// the last 24 hours and the existing/matching peer we already know
-	// has a timestamp also not within the last hour, we set the existing peer's
-	// timestamp to 24 hours ago.
 	if !now.Add(-24*time.Hour).Before(p.GetTimestamp()) && !now.Add(-24*time.Hour).Before(existingPeer.GetTimestamp()) {
 		existingPeer.SetTimestamp(now.Add(-24 * time.Hour))
 		return nil
 	}
 
-	// At this point, we simple update the existing peer's
-	// timestamp with the candidate's peer timestamp
+	// At this point, we simple update
+	// the existing peer's timestamp
 	existingPeer.SetTimestamp(p.GetTimestamp())
 
 	return nil
 }
 
-// KnownPeers returns the map of known peers
-func (m *Manager) KnownPeers() map[string]types.Engine {
-	return m.knownPeers
+// Peers returns the map of known peers
+func (m *Manager) Peers() map[string]types.Engine {
+	m.mtx.RLock()
+	defer m.mtx.RUnlock()
+	return m.peers
 }
 
 // SetKnownPeers sets the known peers
 func (m *Manager) SetKnownPeers(d map[string]types.Engine) {
-	m.knownPeers = d
+	m.mtx.Lock()
+	defer m.mtx.Unlock()
+	m.peers = d
 }
 
-// NeedMorePeers checks whether we need more peers
-func (m *Manager) NeedMorePeers() bool {
+// RequirePeers checks whether we need more peers
+func (m *Manager) RequirePeers() bool {
 	return len(m.GetActivePeers(0)) < 1000 && m.connMgr.needMoreConnections()
 }
 
 // IsLocalNode checks if a peer is the local peer
 func (m *Manager) IsLocalNode(p types.Engine) bool {
-	return p != nil && m.localNode != nil && p.StringID() == m.localNode.StringID()
+	return p != nil && m.localNode != nil && m.localNode.IsSame(p)
 }
 
 // SetLocalNode sets the local node
@@ -346,7 +330,7 @@ func (m *Manager) SetNumActiveConnections(n int64) {
 // IsActive returns true of a peer is considered active.
 // First rule, its timestamp must be within the last 3 hours
 func (m *Manager) IsActive(p types.Engine) bool {
-	return time.Now().Add(-3 * (60 * 60) * time.Second).Before(p.GetTimestamp())
+	return time.Now().UTC().Add(-3 * (60 * 60) * time.Second).Before(p.GetTimestamp())
 }
 
 // HasDisconnected reduces the timestamp of
@@ -359,44 +343,45 @@ func (m *Manager) HasDisconnected(remotePeer types.Engine) error {
 		return fmt.Errorf("nil passed")
 	}
 	remotePeer.SetTimestamp(remotePeer.GetTimestamp().Add(-1 * time.Hour))
-	m.CleanKnownPeers()
+	m.CleanPeers()
 	return nil
 }
 
-// CleanKnownPeers removes old peers from the list
-// of peers known by the local peer. Typically, we remove
-// peers based on the last time they were seen. At least
-// 3 connections must be active before we can clean.
+// CleanPeers removes old peers from the list
+// of peers known by the local peer. Typically,
+// we remove peers based on the last time
+// they were seen. At least 3 connections must
+// be active before we can proceed.
 // It returns the number of peers removed
-func (m *Manager) CleanKnownPeers() int {
+func (m *Manager) CleanPeers() int {
+	m.mtx.Lock()
+	defer m.mtx.Unlock()
 
 	if m.connMgr.connectionCount() < 3 {
 		return 0
 	}
 
-	m.knownPeerMtx.Lock()
-	defer m.knownPeerMtx.Unlock()
-
-	before := len(m.knownPeers)
+	before := len(m.peers)
 
 	newKnownPeers := make(map[string]types.Engine)
-	for k, p := range m.knownPeers {
+	for k, p := range m.peers {
 		if m.IsActive(p) {
 			newKnownPeers[k] = p
 		}
 	}
 
-	m.knownPeers = newKnownPeers
+	m.peers = newKnownPeers
 
 	return before - len(newKnownPeers)
 }
 
-// GetKnownPeers gets all the known peers (active or inactive)
-func (m *Manager) GetKnownPeers() (peers []types.Engine) {
-	m.knownPeerMtx.Lock()
-	defer m.knownPeerMtx.Unlock()
+// GetPeers gets all the known
+// peers (active or inactive)
+func (m *Manager) GetPeers() (peers []types.Engine) {
+	m.mtx.RLock()
+	defer m.mtx.RUnlock()
 
-	for _, p := range m.knownPeers {
+	for _, p := range m.peers {
 		peers = append(peers, p)
 	}
 
@@ -406,9 +391,9 @@ func (m *Manager) GetKnownPeers() (peers []types.Engine) {
 // GetActivePeers returns active peers. Passing a zero or negative value
 // as limit means no limit is applied.
 func (m *Manager) GetActivePeers(limit int) (peers []types.Engine) {
-	m.knownPeerMtx.Lock()
-	defer m.knownPeerMtx.Unlock()
-	for _, p := range m.knownPeers {
+	m.mtx.RLock()
+	defer m.mtx.RUnlock()
+	for _, p := range m.peers {
 		if limit > 0 && len(peers) >= limit {
 			return
 		}
@@ -419,8 +404,12 @@ func (m *Manager) GetActivePeers(limit int) (peers []types.Engine) {
 	return
 }
 
-// CopyActivePeers is like GetActivePeers but a different slice is returned
+// CopyActivePeers is like GetActivePeers
+// but a different slice is returned
 func (m *Manager) CopyActivePeers(limit int) (peers []types.Engine) {
+	m.mtx.RLock()
+	defer m.mtx.RUnlock()
+
 	activePeers := m.GetActivePeers(limit)
 	copiedActivePeers := make([]types.Engine, len(activePeers))
 	copy(copiedActivePeers, activePeers)
@@ -430,25 +419,27 @@ func (m *Manager) CopyActivePeers(limit int) (peers []types.Engine) {
 // GetRandomActivePeers returns a slice of randomly selected peers
 // whose timestamp is within 3 hours ago.
 func (m *Manager) GetRandomActivePeers(limit int) []types.Engine {
+	m.mtx.RLock()
+	defer m.mtx.RUnlock()
 
-	knownActivePeers := m.CopyActivePeers(0)
-	m.knownPeerMtx.Lock()
-	defer m.knownPeerMtx.Unlock()
+	peers := m.CopyActivePeers(0)
 
 	// shuffle known peer slice
-	for i := range knownActivePeers {
+	for i := range peers {
 		j := rand.Intn(i + 1)
-		knownActivePeers[i], knownActivePeers[j] = knownActivePeers[j], knownActivePeers[i]
+		peers[i], peers[j] = peers[j], peers[i]
 	}
 
-	if len(knownActivePeers) <= limit {
-		return knownActivePeers
+	if len(peers) <= limit {
+		return peers
 	}
 
-	return knownActivePeers[:limit]
+	return peers[:limit]
 }
 
-// CreatePeerFromAddress creates a new peer and assign the multiaddr to it.
+// CreatePeerFromAddress creates a
+// new peer and assigns the multiaddr
+// to it.
 func (m *Manager) CreatePeerFromAddress(addr string) error {
 
 	var err error
@@ -465,15 +456,16 @@ func (m *Manager) CreatePeerFromAddress(addr string) error {
 		return nil
 	}
 
-	remotePeer.Timestamp = time.Now()
+	remotePeer.Timestamp = time.Now().UTC()
 	err = m.AddOrUpdatePeer(remotePeer)
 	m.log.Info("Added a peer", "PeerAddr", mAddr.String())
 
 	return err
 }
 
-// deserializePeers takes a slice of bytes which was created by
-// serializeActivePeers and creates new remote node
+// deserializePeers takes a slice of bytes
+// which was created by serializeActivePeers
+// and creates a new remote node instance
 func (m *Manager) deserializePeers(serPeers [][]byte) ([]*Node, error) {
 
 	var peers = make([]*Node, len(serPeers))
@@ -505,7 +497,7 @@ func (m *Manager) SavePeers() error {
 	// eligible
 	peers := m.CopyActivePeers(0)
 	for _, p := range peers {
-		if !p.IsHardcodedSeed() && time.Now().Add(20*time.Minute).Before(p.GetTimestamp()) {
+		if !p.IsHardcodedSeed() && time.Now().UTC().Add(20*time.Minute).Before(p.GetTimestamp()) {
 			key := []byte(p.StringID())
 			value := util.ObjectToBytes(map[string]interface{}{
 				"addr": p.GetMultiAddr(),

--- a/node/peer_mgr_test.go
+++ b/node/peer_mgr_test.go
@@ -66,7 +66,7 @@ var _ = Describe("GetAddr", func() {
 			defer closeNode(p2)
 			err = mgr.AddOrUpdatePeer(p2)
 			Expect(err).To(BeNil())
-			Expect(mgr.KnownPeers()).To(HaveLen(1))
+			Expect(mgr.Peers()).To(HaveLen(1))
 		})
 
 		It("when peer exist but has a different address, return error", func() {
@@ -96,7 +96,7 @@ var _ = Describe("GetAddr", func() {
 	Describe(".CleanKnownPeers", func() {
 
 		It("should return 0 when number of connected peers is less than 3", func() {
-			n := mgr.CleanKnownPeers()
+			n := mgr.CleanPeers()
 			Expect(n).To(BeZero())
 		})
 
@@ -106,14 +106,14 @@ var _ = Describe("GetAddr", func() {
 			addr, _ := ma.NewMultiaddr("/ip4/127.0.0.1/tcp/9000/ipfs/12D3KooWM4yJB31d4hF2F9Vdwuj9WFo1qonoySyw4bVAQ9a9d21o")
 			p2 := node.NewRemoteNode(addr, lp)
 			p2.Timestamp = time.Now()
-			mgr.KnownPeers()[p2.StringID()] = p2
+			mgr.Peers()[p2.StringID()] = p2
 
 			addr2, _ := ma.NewMultiaddr("/ip4/127.0.0.1/tcp/9000/ipfs/12D3KooWM4yJB31d4hF2F9Vdwuj9WFo1qonoySyw4bVAQ9a9d21d")
 			p3 := node.NewRemoteNode(addr2, lp)
 			p3.Timestamp = time.Now()
-			mgr.KnownPeers()[p3.StringID()] = p3
+			mgr.Peers()[p3.StringID()] = p3
 
-			n := mgr.CleanKnownPeers()
+			n := mgr.CleanPeers()
 			Expect(n).To(BeZero())
 		})
 
@@ -123,13 +123,13 @@ var _ = Describe("GetAddr", func() {
 			addr, _ := ma.NewMultiaddr("/ip4/127.0.0.1/tcp/9000/ipfs/12D3KooWM4yJB31d4hF2F9Vdwuj9WFo1qonoySyw4bVAQ9a9d21o")
 			p2 := node.NewRemoteNode(addr, lp)
 			p2.Timestamp = time.Now()
-			mgr.KnownPeers()[p2.StringID()] = p2
+			mgr.Peers()[p2.StringID()] = p2
 
 			addr2, _ := ma.NewMultiaddr("/ip4/127.0.0.1/tcp/9000/ipfs/12D3KooWM4yJB31d4hF2F9Vdwuj9WFo1qonoySyw4bVAQ9a9d21d")
 			p3 := node.NewRemoteNode(addr2, lp)
-			mgr.KnownPeers()[p3.StringID()] = p3
+			mgr.Peers()[p3.StringID()] = p3
 
-			n := mgr.CleanKnownPeers()
+			n := mgr.CleanPeers()
 			Expect(n).To(Equal(1))
 		})
 	})
@@ -142,7 +142,7 @@ var _ = Describe("GetAddr", func() {
 			rp.Timestamp = time.Now()
 
 			mgr = lp.PM()
-			mgr.KnownPeers()[rp.StringID()] = rp
+			mgr.Peers()[rp.StringID()] = rp
 
 			err := mgr.SavePeers()
 			Expect(err).To(BeNil())
@@ -164,8 +164,8 @@ var _ = Describe("GetAddr", func() {
 			p3 := node.NewRemoteNode(addr2, lp)
 			p3.Timestamp = time.Now().Add(21 * time.Minute)
 
-			mgr.KnownPeers()[p2.StringID()] = p2
-			mgr.KnownPeers()[p3.StringID()] = p3
+			mgr.Peers()[p2.StringID()] = p2
+			mgr.Peers()[p3.StringID()] = p3
 
 			err := mgr.SavePeers()
 			Expect(err).To(BeNil())
@@ -184,18 +184,18 @@ var _ = Describe("GetAddr", func() {
 			p2.Timestamp = time.Now().Add(21 * time.Minute)
 			p3 := node.NewRemoteNode(addr2, lp)
 			p3.Timestamp = time.Now().Add(21 * time.Minute)
-			mgr.KnownPeers()[p2.StringID()] = p2
-			mgr.KnownPeers()[p3.StringID()] = p3
+			mgr.Peers()[p2.StringID()] = p2
+			mgr.Peers()[p3.StringID()] = p3
 			err := mgr.SavePeers()
 			Expect(err).To(BeNil())
-			Expect(mgr.KnownPeers()).To(HaveLen(2))
+			Expect(mgr.Peers()).To(HaveLen(2))
 		})
 
 		It("should fetch", func() {
 			mgr.SetKnownPeers(map[string]types.Engine{})
 			err := mgr.LoadPeers()
 			Expect(err).To(BeNil())
-			Expect(mgr.KnownPeers()).To(HaveLen(2))
+			Expect(mgr.Peers()).To(HaveLen(2))
 		})
 	})
 
@@ -204,7 +204,7 @@ var _ = Describe("GetAddr", func() {
 		It("should return nil when peer is not in known peer list", func() {
 			p2, err := node.NewNode(cfg, "127.0.0.1:40002", crypto.NewKeyFromIntSeed(0), log)
 			Expect(err).To(BeNil())
-			Expect(mgr.GetKnownPeer(p2.StringID())).To(BeNil())
+			Expect(mgr.GetPeer(p2.StringID())).To(BeNil())
 			p2.GetHost().Close()
 		})
 
@@ -212,7 +212,7 @@ var _ = Describe("GetAddr", func() {
 			p2, err := node.NewNode(cfg, "127.0.0.1:40003", crypto.NewKeyFromIntSeed(3), log)
 			mgr.AddOrUpdatePeer(p2)
 			Expect(err).To(BeNil())
-			actual := mgr.GetKnownPeer(p2.StringID())
+			actual := mgr.GetPeer(p2.StringID())
 			Expect(actual).NotTo(BeNil())
 			Expect(actual).To(Equal(p2))
 			p2.GetHost().Close()
@@ -262,7 +262,7 @@ var _ = Describe("GetAddr", func() {
 			p2, err := node.NewNode(cfg, "127.0.0.1:40002", crypto.NewKeyFromIntSeed(0), log)
 			Expect(err).To(BeNil())
 			mgr.AddOrUpdatePeer(p2)
-			actual := mgr.GetKnownPeers()
+			actual := mgr.GetPeers()
 			Expect(actual).To(HaveLen(1))
 			Expect(actual).To(ContainElement(p2))
 		})
@@ -287,16 +287,16 @@ var _ = Describe("GetAddr", func() {
 		It("peer with address '/ip4/127.0.0.1/tcp/40004/ipfs/12D3KooWHHzSeKaY8xuZVzkLbKFfvNgPPeKhFBGrMbNzbm5akpqd' must be added", func() {
 			err := mgr.CreatePeerFromAddress(address)
 			Expect(err).To(BeNil())
-			p := mgr.KnownPeers()["12D3KooWHHzSeKaY8xuZVzkLbKFfvNgPPeKhFBGrMbNzbm5akpqd"]
+			p := mgr.Peers()["12D3KooWHHzSeKaY8xuZVzkLbKFfvNgPPeKhFBGrMbNzbm5akpqd"]
 			Expect(p).NotTo(BeNil())
 		})
 
 		It("duplicate peer should be not be recreated", func() {
-			Expect(len(mgr.KnownPeers())).To(Equal(0))
+			Expect(len(mgr.Peers())).To(Equal(0))
 			mgr.CreatePeerFromAddress(address)
-			Expect(len(mgr.KnownPeers())).To(Equal(1))
+			Expect(len(mgr.Peers())).To(Equal(1))
 			mgr.CreatePeerFromAddress(address)
-			Expect(len(mgr.KnownPeers())).To(Equal(1))
+			Expect(len(mgr.Peers())).To(Equal(1))
 		})
 	})
 
@@ -385,7 +385,7 @@ var _ = Describe("GetAddr", func() {
 		It("should return a different slice from the original knownPeer slice", func() {
 			actual := mgr.CopyActivePeers(1)
 			Expect(actual).To(HaveLen(1))
-			Expect(actual).NotTo(Equal(mgr.KnownPeers))
+			Expect(actual).NotTo(Equal(mgr.Peers))
 		})
 	})
 
@@ -451,7 +451,7 @@ var _ = Describe("GetAddr", func() {
 			mgr.SetKnownPeers(map[string]types.Engine{
 				"peer1": peer1,
 			})
-			Expect(mgr.NeedMorePeers()).To(BeTrue())
+			Expect(mgr.RequirePeers()).To(BeTrue())
 		})
 
 		It("should return false when peer manager does not have upto 1000 peers and but has reached max connection", func() {
@@ -461,7 +461,7 @@ var _ = Describe("GetAddr", func() {
 			mgr.SetKnownPeers(map[string]types.Engine{
 				"peer1": peer1,
 			})
-			Expect(mgr.NeedMorePeers()).To(BeFalse())
+			Expect(mgr.RequirePeers()).To(BeFalse())
 		})
 	})
 

--- a/node/ping.go
+++ b/node/ping.go
@@ -67,7 +67,7 @@ func (g *Gossip) SendPingToPeer(remotePeer types.Engine) error {
 	// update the remote peer's timestamp
 	// and add the remote peer to the peer manager's list
 	remotePeer.SetTimestamp(time.Now().UTC())
-	g.PM().AddOrUpdatePeer(remotePeer)
+	g.PM().UpdatePeerTime(remotePeer)
 
 	g.log.Info("Received pong response from peer", "PeerID", remotePeerIDShort)
 
@@ -156,7 +156,7 @@ func (g *Gossip) OnPing(s net.Stream) {
 
 	// update the remote peer's timestamp in the peer manager's list
 	remotePeer.SetTimestamp(time.Now().UTC())
-	g.PM().AddOrUpdatePeer(remotePeer)
+	g.PM().UpdatePeerTime(remotePeer)
 
 	g.log.Info("Sent pong response to peer", "PeerID", remotePeerIDShort)
 

--- a/node/ping.go
+++ b/node/ping.go
@@ -56,7 +56,7 @@ func (g *Gossip) SendPingToPeer(remotePeer types.Engine) error {
 		return fmt.Errorf("ping failed. failed to write to stream")
 	}
 
-	g.PM().UpdatePeerTime(remotePeer)
+	g.PM().UpdateLastSeen(remotePeer)
 	g.log.Debug("Sent ping to peer",
 		"PeerID", remotePeerIDShort)
 
@@ -69,7 +69,7 @@ func (g *Gossip) SendPingToPeer(remotePeer types.Engine) error {
 	}
 
 	// update the remote peer's timestamp
-	g.PM().UpdatePeerTime(remotePeer)
+	g.PM().UpdateLastSeen(remotePeer)
 
 	g.log.Info("Received pong response from peer",
 		"PeerID", remotePeerIDShort)
@@ -164,7 +164,7 @@ func (g *Gossip) OnPing(s net.Stream) {
 	}
 
 	// update the remote peer's timestamp
-	g.PM().UpdatePeerTime(remotePeer)
+	g.PM().UpdateLastSeen(remotePeer)
 
 	g.log.Debug("Sent pong response to peer", "PeerID", remotePeerIDShort)
 

--- a/node/ping_test.go
+++ b/node/ping_test.go
@@ -73,15 +73,15 @@ var _ = Describe("Ping", func() {
 			var rpBeforePingTime int64
 
 			BeforeEach(func() {
-				lp.PM().UpdatePeerTime(rp)
-				rp.SetTimestamp(time.Now().Add(-2 * time.Hour))
-				rpBeforePingTime = rp.GetTimestamp().Unix()
+				lp.PM().UpdateLastSeen(rp)
+				rp.SetLastSeen(time.Now().Add(-2 * time.Hour))
+				rpBeforePingTime = rp.GetLastSeen().Unix()
 			})
 
 			It("should return nil and update remote peer timestamp locally", func() {
 				err := lp.Gossip().SendPingToPeer(rp)
 				Expect(err).To(BeNil())
-				rpAfterPingTime := rp.GetTimestamp().Unix()
+				rpAfterPingTime := rp.GetLastSeen().Unix()
 				Expect(rpAfterPingTime > rpBeforePingTime).To(BeTrue())
 			})
 		})

--- a/node/ping_test.go
+++ b/node/ping_test.go
@@ -73,7 +73,7 @@ var _ = Describe("Ping", func() {
 			var rpBeforePingTime int64
 
 			BeforeEach(func() {
-				lp.PM().AddOrUpdatePeer(rp)
+				lp.PM().UpdatePeerTime(rp)
 				rp.SetTimestamp(time.Now().Add(-2 * time.Hour))
 				rpBeforePingTime = rp.GetTimestamp().Unix()
 			})

--- a/node/self_adv.go
+++ b/node/self_adv.go
@@ -39,7 +39,7 @@ func (g *Gossip) SelfAdvertise(connectedPeers []types.Engine) int {
 			continue
 		}
 
-		g.PM().UpdatePeerTime(peer)
+		g.PM().UpdateLastSeen(peer)
 
 		sent++
 	}

--- a/node/self_adv_test.go
+++ b/node/self_adv_test.go
@@ -41,7 +41,7 @@ var _ = Describe("GetAddr", func() {
 			}()
 
 			<-rp.GetEventEmitter().Once(node.EventAddrProcessed)
-			knownPeers := rp.PM().GetKnownPeers()
+			knownPeers := rp.PM().GetPeers()
 			Expect(knownPeers).To(HaveLen(1))
 			Expect(knownPeers[0].StringID()).To(Equal(lp.StringID()))
 			close(done)

--- a/node/transaction_test.go
+++ b/node/transaction_test.go
@@ -119,7 +119,7 @@ var _ = Describe("Transaction", func() {
 
 			It("should return error about unexpected allocation transaction", func() {
 				Expect(evt.Args).To(HaveLen(1))
-				Expect(evt.Args[0].(error).Error()).To(Equal("unexpected allocation transaction received"))
+				Expect(evt.Args[0].(error).Error()).To(Equal("Unexpected allocation transaction received"))
 			})
 		})
 

--- a/rpc/jsonrpc/api.go
+++ b/rpc/jsonrpc/api.go
@@ -1,6 +1,10 @@
 package jsonrpc
 
-import "github.com/ellcrys/elld/util"
+import (
+	"strings"
+
+	"github.com/ellcrys/elld/util"
+)
 
 // Params represent JSON API parameters
 type Params map[string]interface{}
@@ -31,11 +35,19 @@ type APIInfo struct {
 // APISet defines a collection of APIs
 type APISet map[string]APIInfo
 
-// Get gets an API function by name.
+// Get gets an API function by name
+// and namespace
 func (a APISet) Get(name string) *APIInfo {
-	if api, ok := a[name]; ok {
+	nameParts := strings.Split(name, "_")
+
+	if len(nameParts) != 2 {
+		return nil
+	}
+
+	if api, ok := a[nameParts[1]]; ok && api.Namespace == nameParts[0] {
 		return &api
 	}
+
 	return nil
 }
 

--- a/types/engine.go
+++ b/types/engine.go
@@ -31,4 +31,6 @@ type Engine interface {
 	GetBlockchain() core.Blockchain       // Returns the blockchain manager
 	SetBlockchain(bchain core.Blockchain) // Set the blockchain manager
 	ProdMode() bool                       // Checks whether the current mode is ModeProd
+	Acquainted()                          // Sets the acquainted status to true
+	IsAcquainted() bool                   // Returns the acquainted status
 }

--- a/types/engine.go
+++ b/types/engine.go
@@ -22,10 +22,12 @@ type Engine interface {
 	ShortID() string                      // Return the short version of the engine ID
 	ID() peer.ID                          // Get the ID as issued by libp2p
 	GetIP4TCPAddr() ma.Multiaddr          // Returns the ipv4 address of the engine
-	GetTimestamp() time.Time              // Returns the timestamp of the engine
-	SetTimestamp(time.Time)               // Set the engine's timestamp
+	GetLastSeen() time.Time               // Returns the timestamp of the engine
+	SetLastSeen(time.Time)                // Set the engine's timestamp
+	CreatedAt() time.Time                 // Returns the time the node was created
+	SetCreatedAt(t time.Time)             // Set the time the node was created locally
 	IsSame(Engine) bool                   // Checks whether an remote node has same ID as the engine
-	IsHardcodedSeed() bool                // Checks whether the engine is an hardcoded seed peer
+	IsHardcodedSeed() bool                // Checks whether the engine is an hardcoded seed node
 	GetMultiAddr() string                 // Returns the multiaddr of the node
 	Connected() bool                      // Returns true if engine is connected to its local node
 	GetBlockchain() core.Blockchain       // Returns the blockchain manager

--- a/util/address.go
+++ b/util/address.go
@@ -47,8 +47,8 @@ func IsRoutableAddr(addr string) bool {
 	return IsRoutable(net.ParseIP(ip))
 }
 
-// FullRemoteAddressFromStream returns the full peer multi address containing ip4, tcp and ipfs protocols
-func FullRemoteAddressFromStream(s inet.Stream) ma.Multiaddr {
+// RemoteAddressFromStream returns the full peer multi address containing ip4, tcp and ipfs protocols
+func RemoteAddressFromStream(s inet.Stream) ma.Multiaddr {
 	if s == nil {
 		return nil
 	}

--- a/util/address_test.go
+++ b/util/address_test.go
@@ -52,7 +52,7 @@ var _ = Describe("Address", func() {
 		})
 
 		It("should return nil if nil is passed", func() {
-			addr := FullRemoteAddressFromStream(nil)
+			addr := RemoteAddressFromStream(nil)
 			Expect(addr).To(BeNil())
 		})
 
@@ -67,7 +67,7 @@ var _ = Describe("Address", func() {
 			Expect(err).To(BeNil())
 			defer host.Close()
 
-			addr := FullRemoteAddressFromStream(s)
+			addr := RemoteAddressFromStream(s)
 			Expect(addr.String()).To(Equal("/ip4/127.0.0.1/tcp/40101/ipfs/12D3KooWE3AwZFT9zEWDUxhya62hmvEbRxYBWaosn7Kiqw5wsu73"))
 		})
 	})

--- a/wire/message.go
+++ b/wire/message.go
@@ -9,7 +9,8 @@ import (
 	"github.com/vmihailenco/msgpack"
 )
 
-// Handshake represents the first message between peers
+// Handshake represents the first
+// message between peers
 type Handshake struct {
 	SubVersion               string    `json:"subversion" msgpack:"subversion"`
 	BestBlockHash            util.Hash `json:"bestBlockHash" msgpack:"bestBlockHash"`
@@ -17,13 +18,15 @@ type Handshake struct {
 	BestBlockNumber          uint64    `json:"bestBlockNumber" msgpack:"bestBlockNumber"`
 }
 
-// EncodeMsgpack implements msgpack.CustomEncoder
+// EncodeMsgpack implements
+// msgpack.CustomEncoder
 func (h *Handshake) EncodeMsgpack(enc *msgpack.Encoder) error {
 	tdStr := h.BestBlockTotalDifficulty.String()
 	return enc.Encode(h.SubVersion, h.BestBlockHash, h.BestBlockNumber, tdStr)
 }
 
-// DecodeMsgpack implements msgpack.CustomDecoder
+// DecodeMsgpack implements
+// msgpack.CustomDecoder
 func (h *Handshake) DecodeMsgpack(dec *msgpack.Decoder) error {
 	var tdStr string
 	if err := dec.Decode(&h.SubVersion, &h.BestBlockHash, &h.BestBlockNumber, &tdStr); err != nil {
@@ -33,16 +36,18 @@ func (h *Handshake) DecodeMsgpack(dec *msgpack.Decoder) error {
 	return nil
 }
 
-// GetAddr is used to request for peer addresses from other peers
+// GetAddr is used to request for peer
+// addresses from other peers
 type GetAddr struct {
 }
 
-// Addr is used to send peer addresses in response to a GetAddr
+// Addr is used to send peer addresses
+// in response to a GetAddr
 type Addr struct {
 	Addresses []*Address `json:"addresses" msgpack:"addresses"`
 }
 
-// Address represents a peer address
+// Address represents a peer's address
 type Address struct {
 	Address   string `json:"address" msgpack:"address"`
 	Timestamp int64  `json:"timestamp" msgpack:"timestamp"`


### PR DESCRIPTION
### Commit Summary

* Remove redundant checks in peer time stamp update method.
* Fixed issue that caused a deadlock situation in test when updating peer timestamp.
* Formated comments to  not be excessively vertically long.
* `NewStream` now includes a timeout contexts and no longer accepts context as argument.
* On most gossip message handlers, remote peer timestamp is now updated after receiving or writing to them.
* Namespaces are now required when calling rpc methods. Before, rpc methods are called by their bare method names e.g `info`. Now, their namespace most precede the method name e.g `node_info`.
* Now storing creation time of a peer address.
* Renamed `Timestamp` to `lastSeen` which is a more descriptive name.
