### PR TITLE
Message Broadcasters & Intro Improvement

### DIFF
--- a/node/api.go
+++ b/node/api.go
@@ -2,7 +2,6 @@ package node
 
 import (
 	"encoding/base64"
-	"fmt"
 
 	"github.com/ellcrys/elld/config"
 
@@ -149,9 +148,6 @@ func (n *Node) apiAddPeer(arg interface{}) *jsonrpc.Response {
 // number of peers connected to
 func (n *Node) apiNetInfo(arg interface{}) *jsonrpc.Response {
 	var connsInfo = n.peerManager.connMgr.GetConnsCount()
-	for _, i := range n.intros.Keys() {
-		fmt.Println(n.intros.Get(i), i)
-	}
 	var result = map[string]int{
 		"total":    connsInfo.Outbound + connsInfo.Inbound,
 		"inbound":  connsInfo.Inbound,

--- a/node/handshake.go
+++ b/node/handshake.go
@@ -7,6 +7,7 @@ import (
 	"github.com/ellcrys/elld/types"
 	"github.com/ellcrys/elld/types/core"
 	"github.com/ellcrys/elld/util"
+	"github.com/ellcrys/elld/util/cache"
 	"github.com/ellcrys/elld/util/logger"
 	"github.com/ellcrys/elld/wire"
 	"github.com/jinzhu/copier"
@@ -116,6 +117,9 @@ func (g *Gossip) SendHandshake(remotePeer types.Engine) error {
 	copier.Copy(&bestBlockInfo, resp)
 	g.engine.updateSyncInfo(&bestBlockInfo)
 
+	// Add remote peer into the intro cache with a TTL of 1 hour.
+	g.engine.intros.AddWithExp(remotePeer.StringID(), struct{}{}, cache.Sec(3600))
+
 	return nil
 }
 
@@ -196,4 +200,7 @@ func (g *Gossip) OnHandshake(s net.Stream) {
 	var bestBlockInfo BestBlockInfo
 	copier.Copy(&bestBlockInfo, msg)
 	g.engine.updateSyncInfo(&bestBlockInfo)
+
+	// Add remote peer into the intro cache with a TTL of 1 hour.
+	g.engine.intros.AddWithExp(remotePeer.StringID(), struct{}{}, cache.Sec(3600))
 }

--- a/node/peer_mgr_test.go
+++ b/node/peer_mgr_test.go
@@ -309,7 +309,7 @@ var _ = Describe("Peer Manager", func() {
 		})
 
 		It("", func() {
-			
+
 		})
 	})
 


### PR DESCRIPTION
## Commits Summary

### Node
* Message broadcasters are now represented by a custom type `Broadcaster` which is a map. This enables fast lookup and naturally prevents duplicates.
* After a successful handshake, an entry is added in `intro` cache for the remote peer.