### PR TITLE
Transaction Pool Event & Data Races

### DIFF
--- a/cmd/start.go
+++ b/cmd/start.go
@@ -198,6 +198,9 @@ func start(cmd *cobra.Command, args []string, startConsole bool) (*node.Node, *r
 
 	log.Info("Elld has started", "Version", config.ClientVersion, "DevMode", devMode)
 
+	// Create event the global event handler
+	event := &emitter.Emitter{}
+
 	// Create the local node.
 	n, err := node.NewNode(cfg, listeningAddr, coinbase, log)
 	if err != nil {
@@ -210,8 +213,9 @@ func start(cmd *cobra.Command, args []string, startConsole bool) (*node.Node, *r
 		log.SetToDebug()
 	}
 
-	// Configure transactions pool
+	// Configure transactions pool and assign to node
 	pool := txpool.New(params.PoolCapacity)
+	pool.SetEventEmitter(event)
 	n.SetTxsPool(pool)
 
 	// Add hardcoded bootstrap addresses
@@ -245,9 +249,6 @@ func start(cmd *cobra.Command, args []string, startConsole bool) (*node.Node, *r
 	n.SetProtocolHandler(config.RequestBlockVersion, protocol.OnRequestBlock)
 	n.SetProtocolHandler(config.GetBlockHashesVersion, protocol.OnGetBlockHashes)
 	n.SetProtocolHandler(config.GetBlockBodiesVersion, protocol.OnGetBlockBodies)
-
-	// Create event the global event handler
-	event := &emitter.Emitter{}
 
 	// Instantiate the blockchain manager,
 	// set db, event emitter and pass it to the engine

--- a/elldb/leveldb.go
+++ b/elldb/leveldb.go
@@ -3,6 +3,7 @@ package elldb
 import (
 	"fmt"
 	path "path/filepath"
+	"sync"
 
 	"github.com/syndtr/goleveldb/leveldb"
 	"github.com/syndtr/goleveldb/leveldb/errors"
@@ -17,6 +18,7 @@ const dbfile = "data%s.db"
 // LevelDB provides local data storage and functionalities for various purpose.
 // It implements DB interface
 type LevelDB struct {
+	sync.Mutex
 	dataDir string
 	ldb     *leveldb.DB
 }
@@ -58,9 +60,15 @@ func (db *LevelDB) Open(namespace string) error {
 
 // Close closes the database
 func (db *LevelDB) Close() error {
+	db.Lock()
+	db.Unlock()
+
 	if db.ldb != nil {
 		return db.ldb.Close()
 	}
+
+	db.ldb = nil
+
 	return nil
 }
 

--- a/node/addr_test.go
+++ b/node/addr_test.go
@@ -62,9 +62,9 @@ var _ = Describe("Addr", func() {
 			When("many candidate addresses is passed", func() {
 				It("should return N nodes", func() {
 					broadcasters := lp.Gossip().PickBroadcasters(candidateAddrs, 2)
-					Expect(broadcasters).To(HaveLen(2))
-					Expect(broadcasters).To(HaveKey(candidateAddrs[2].Address.StringID()))
-					Expect(broadcasters).To(HaveKey(candidateAddrs[1].Address.StringID()))
+					Expect(broadcasters.Len()).To(Equal(2))
+					Expect(broadcasters.PeersID()).To(ContainElement(candidateAddrs[2].Address.StringID()))
+					Expect(broadcasters.PeersID()).To(ContainElement(candidateAddrs[1].Address.StringID()))
 				})
 			})
 
@@ -75,24 +75,27 @@ var _ = Describe("Addr", func() {
 
 				It("Should return the only candidate node", func() {
 					broadcasters := lp.Gossip().PickBroadcasters(candidateAddrs, 2)
-					Expect(broadcasters).To(HaveLen(1))
-					Expect(broadcasters).To(HaveKey(candidateAddrs[0].Address.StringID()))
+					Expect(broadcasters.Len()).To(Equal(1))
+					Expect(broadcasters.PeersID()).To(ContainElement(candidateAddrs[0].Address.StringID()))
 				})
 			})
 		})
 
 		When("cache has one address and multiple candidate addresses", func() {
 			var addr = util.NodeAddr("/ip4/172.16.238.14/tcp/9000/ipfs/12D3KooWE4qDcRrueTuRYWUdQZgcy7APZqBngVeXRt4Y6ytHizKV")
+			var broadcasters *node.BroadcastPeers
 
 			BeforeEach(func() {
 				n, _ := rp.NodeFromAddr(addr, true)
-				lp.Gossip().GetBroadcasters().Add(n)
+				broadcasters = lp.Gossip().GetBroadcasters()
+				broadcasters.Add(n)
+				Expect(broadcasters.Len()).To(Equal(1))
 			})
 
 			It("should clear the cache and select new addresses", func() {
-				broadcasters := lp.Gossip().PickBroadcasters(candidateAddrs, 2)
-				Expect(broadcasters).To(HaveLen(2))
-				Expect(broadcasters).To(HaveKey(addr.StringID()))
+				broadcasters = lp.Gossip().PickBroadcasters(candidateAddrs, 2)
+				Expect(broadcasters.Len()).To(Equal(2))
+				Expect(broadcasters.PeersID()).ToNot(ContainElement(addr.StringID()))
 			})
 		})
 
@@ -109,14 +112,14 @@ var _ = Describe("Addr", func() {
 
 			It("should leave the cache untouched and add the only candidate address", func() {
 				broadcasters := lp.Gossip().PickBroadcasters(candidateAddrs, 2)
-				Expect(broadcasters).To(HaveLen(2))
-				Expect(broadcasters).To(HaveKey(addr.StringID()))
-				Expect(broadcasters).To(HaveKey(candidateAddrs[0].Address.StringID()))
+				Expect(broadcasters.Len()).To(Equal(2))
+				Expect(broadcasters.PeersID()).To(ContainElement(addr.StringID()))
+				Expect(broadcasters.PeersID()).To(ContainElement(candidateAddrs[0].Address.StringID()))
 			})
 		})
 
 		When("cache has not expired", func() {
-			var broadcasters node.BroadcastPeers
+			var broadcasters *node.BroadcastPeers
 			var candidateAddrs = []*wire.Address{
 				{Address: "/ip4/172.16.238.10/tcp/9000/ipfs/12D3KooWHHzSeKaY8xuZVzkLbKFfvNgPPeKhFBGrMbNzbm5akpqu"},
 				{Address: "/ip4/172.16.238.12/tcp/9000/ipfs/12D3KooWPgam4TzSVCRa4AbhxQnM9abCYR4E9hV57SN7eAjEYn1j"},
@@ -127,7 +130,7 @@ var _ = Describe("Addr", func() {
 
 			BeforeEach(func() {
 				broadcasters = lp.Gossip().PickBroadcasters(candidateAddrs, 2)
-				Expect(broadcasters).To(HaveLen(2))
+				Expect(broadcasters.Len()).To(Equal(2))
 			})
 
 			It("should return current cache values", func() {

--- a/node/api.go
+++ b/node/api.go
@@ -153,10 +153,11 @@ func (n *Node) apiAddPeer(arg interface{}) *jsonrpc.Response {
 // number of peers connected to
 func (n *Node) apiNetInfo(arg interface{}) *jsonrpc.Response {
 	var connsInfo = n.peerManager.connMgr.GetConnsCount()
+	in, out := connsInfo.Info()
 	var result = map[string]int{
-		"total":    connsInfo.Outbound + connsInfo.Inbound,
-		"inbound":  connsInfo.Inbound,
-		"outbound": connsInfo.Outbound,
+		"total":    out + in,
+		"inbound":  in,
+		"outbound": out,
 		"intros":   n.CountIntros(),
 	}
 	return jsonrpc.Success(result)

--- a/node/intro.go
+++ b/node/intro.go
@@ -25,7 +25,7 @@ func (g *Gossip) SendIntro(intro *wire.Intro) {
 	}
 
 	// From our peer list, randomly pick 2 peers to broad cast to.
-	broadcasters := g.PickBroadcasters(connectedAddresses, 2)
+	g.PickBroadcasters(connectedAddresses, 2)
 
 	var msg = intro
 	if msg == nil {
@@ -35,7 +35,7 @@ func (g *Gossip) SendIntro(intro *wire.Intro) {
 	// Send intro message to the selected
 	// broadcast nodes.
 	sent := 0
-	for _, peer := range broadcasters {
+	for _, peer := range g.broadcasters.Peers() {
 
 		// Don't relay an intro back to the
 		// peer that authored it
@@ -75,7 +75,7 @@ func (g *Gossip) SendIntro(intro *wire.Intro) {
 	}
 
 	g.log.Debug("Sent Intro to peer(s)",
-		"NumBroadcastPeers", broadcasters.Len(),
+		"NumBroadcastPeers", g.broadcasters.Len(),
 		"NumSentTo", sent)
 }
 

--- a/node/peer_mgr_test.go
+++ b/node/peer_mgr_test.go
@@ -441,7 +441,7 @@ var _ = Describe("Peer Manager", func() {
 			Context("when max outbound connection has been reached", func() {
 				It("should return false", func() {
 					cfg.Node.MaxOutboundConnections = 10
-					mgr.ConnMgr().SetConnsInfo(&node.ConnsInfo{Outbound: 10})
+					mgr.ConnMgr().SetConnsInfo(node.NewConnsInfo(0, 10))
 					peer1 := emptyNodeWithLastSeenTime(time.Now().Add(-1 * (60 * 60) * time.Second))
 					mgr.SetPeers(map[string]types.Engine{"peer1": peer1})
 					Expect(mgr.RequirePeers()).To(BeFalse())


### PR DESCRIPTION
### Commit Summary

* Fixed data race that occurred when multiple goroutines tried to access the broadcaster peers' cache.
* Fixed data race that occurred when multiple goroutines tried to read/update connection information.
* Fixed data race issue due to concurrent attempted to close the database.
* Pass the same emitter used by the engine to pool