### PR TITLE
Discard Read-Only Transactions Properly

### DIFF
--- a/blockchain/common/types.go
+++ b/blockchain/common/types.go
@@ -32,6 +32,17 @@ func (t *TxOp) GetName() string {
 	return "TxOp"
 }
 
+// Discard the transaction. Do not call
+// functions in the transaction after this.
+func (t *TxOp) Discard() error {
+	if !t.CanFinish || t.finished {
+		return nil
+	}
+	t.Tx.Discard()
+	t.finished = true
+	return nil
+}
+
 // Commit commits the transaction if it has not been done before.
 // It ignores the call if CanFinish is false.
 func (t *TxOp) Commit() error {

--- a/elldb/leveldb.go
+++ b/elldb/leveldb.go
@@ -215,6 +215,13 @@ func (tx *Transaction) Commit() error {
 	return tx.ldb.Commit()
 }
 
+// Discard the transaction
+func (tx *Transaction) Discard() {
+	tx.Lock()
+	defer tx.Unlock()
+	tx.ldb.Discard()
+}
+
 // Rollback discards the transaction
 func (tx *Transaction) Rollback() {
 	tx.Lock()

--- a/elldb/leveldb.go
+++ b/elldb/leveldb.go
@@ -181,6 +181,7 @@ func (db *LevelDB) NewTx() (Tx, error) {
 
 // Transaction defines interface for working with a database transaction
 type Transaction struct {
+	sync.Mutex
 	ldb *leveldb.Transaction
 }
 
@@ -209,11 +210,15 @@ func (tx *Transaction) Iterate(prefix []byte, first bool, iterFunc func(kv *KVOb
 
 // Commit the transaction
 func (tx *Transaction) Commit() error {
+	tx.Lock()
+	defer tx.Unlock()
 	return tx.ldb.Commit()
 }
 
 // Rollback discards the transaction
 func (tx *Transaction) Rollback() {
+	tx.Lock()
+	defer tx.Unlock()
 	tx.ldb.Discard()
 }
 

--- a/elldb/types.go
+++ b/elldb/types.go
@@ -111,6 +111,10 @@ type Tx interface {
 
 	// Rollback roles back the transaction
 	Rollback()
+
+	// Discard the transaction. Do not call
+	// functions in the transaction after this.
+	Discard()
 }
 
 // DB describes the database access, model and available functionalities

--- a/node/api.go
+++ b/node/api.go
@@ -260,6 +260,25 @@ func (n *Node) apiFetchPool(arg interface{}) *jsonrpc.Response {
 func (n *Node) APIs() jsonrpc.APISet {
 	return map[string]jsonrpc.APIInfo{
 
+		// namespace: "logger"
+		"debug": {
+			Namespace:   types.NamespaceLogger,
+			Description: "Set log level to DEBUG",
+			Func: func(arg interface{}) *jsonrpc.Response {
+				n.log.SetToDebug()
+				return jsonrpc.Success(nil)
+			},
+		},
+
+		"default": {
+			Namespace:   types.NamespaceLogger,
+			Description: "Set log level to the default (INFO)",
+			Func: func(arg interface{}) *jsonrpc.Response {
+				n.log.SetToInfo()
+				return jsonrpc.Success(nil)
+			},
+		},
+
 		// namespace: "node"
 		"config": {
 			Namespace:   types.NamespaceNode,

--- a/types/others.go
+++ b/types/others.go
@@ -42,8 +42,12 @@ const (
 	NamespaceNet = "net"
 
 	// NamespaceRPC is the namespace for RPC methods
-	// that perform rpc  actions
+	// that perform rpc actions
 	NamespaceRPC = "rpc"
+
+	// NamespaceLogger is the namespace for RPC methods
+	// for configuring the logger
+	NamespaceLogger = "logger"
 )
 
 // ValidationContext is used to

--- a/util/logger/logging.go
+++ b/util/logger/logging.go
@@ -3,6 +3,7 @@ package logger
 // Logger represents an interface for a logger
 type Logger interface {
 	SetToDebug()
+	SetToInfo()
 	Debug(msg string, keyValues ...interface{})
 	Info(msg string, keyValues ...interface{})
 	Error(msg string, keyValues ...interface{})

--- a/util/logger/logrus.go
+++ b/util/logger/logrus.go
@@ -95,6 +95,11 @@ func (l *Logrus) SetToDebug() {
 	l.log.SetLevel(logrus.DebugLevel)
 }
 
+// SetToInfo sets the logger to INFO level
+func (l *Logrus) SetToInfo() {
+	l.log.SetLevel(logrus.InfoLevel)
+}
+
 func (l *Logrus) toFields(kv []interface{}) (f logrus.Fields) {
 	f = logrus.Fields{}
 	for i := 0; i < len(kv); i++ {


### PR DESCRIPTION
### Commit Summary

#### Elldb

The `Store` creates new transactions for each CRUD operation and commit/rollback the transactions as needed. However, we used to commit transactions that were created to read an object as a way to do away with the transaction's session. The proper thing to do is to call `Discard`. 