### PR TITLE
BlockManager Event Handling, Dockerfile/Makefile Improvements & Key Splitting

### DIFF
--- a/.goreleaser.linux.yml
+++ b/.goreleaser.linux.yml
@@ -6,8 +6,6 @@ builds:
     main: ./main.go
     goos:
       - linux
-      - darwin
-      - windows
     goarch:
       - amd64
     goarm:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,12 @@
 FROM golang:1.10.5-stretch
 
+ARG version=latest
+
 # Download the latest release
 RUN apt-get update
 RUN apt-get install -y jq
-RUN export elldVersion=$(curl -sL https://api.github.com/repos/ellcrys/elld/releases/latest | jq -r '.assets[].browser_download_url | match("(.*(elld_0.1.0-alpha)_linux.*)") | .captures[1].string')
-RUN curl -L $(curl -sL https://api.github.com/repos/ellcrys/elld/releases/latest | jq -r '.assets[].browser_download_url | match("(.*linux.*)") | '.string'') > elld_${elldVersion}_linux_x86_64.tar.gz
+RUN export elldVersion=$(curl -sL https://api.github.com/repos/ellcrys/elld/releases/${version} | jq -r '.assets[].browser_download_url | match("(.*(elld_0.1.0-alpha)_linux.*)") | .captures[1].string')
+RUN curl -L $(curl -sL https://api.github.com/repos/ellcrys/elld/releases/${version} | jq -r '.assets[].browser_download_url | match("(.*linux.*)") | '.string'') > elld_${elldVersion}_linux_x86_64.tar.gz
 RUN mkdir elld_${elldVersion}
 RUN tar -xf elld_${elldVersion}_linux_x86_64.tar.gz -C elld_${elldVersion}
 RUN mv elld_${elldVersion}/elld /usr/local/bin/elld

--- a/Dockerfile.local
+++ b/Dockerfile.local
@@ -1,0 +1,12 @@
+FROM golang:1.10.5-stretch
+
+ARG version=latest
+
+# Move Elld binary from host
+ADD ./dist/linux_amd64 /dist
+RUN mv /dist/elld /usr/local/bin/elld
+
+# Start client
+EXPOSE 9000
+EXPOSE 8999
+ENTRYPOINT ["elld", "start", "-a", "0.0.0.0:9000"]

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -167,14 +167,6 @@
   revision = "02af3965c54e8cacf948b97fef38925c4120652c"
 
 [[projects]]
-  branch = "master"
-  digest = "1:93d6687fc19da8a35c7352d72117a6acd2072dfb7e9bfd65646227bf2a913b2a"
-  name = "github.com/ellcrys/abool"
-  packages = ["."]
-  pruneopts = "UT"
-  revision = "9b9efcf221b50905aab9bbabd3daed56dc10f339"
-
-[[projects]]
   digest = "1:f34e8dee87ed7ebb9caceae96b7851d99ab5bca0afc345cf964c61dc0ad56eb8"
   name = "github.com/ellcrys/go-ethereum"
   packages = ["log"]
@@ -1328,7 +1320,6 @@
     "github.com/cenkalti/rpc2",
     "github.com/dgrijalva/jwt-go",
     "github.com/dustin/go-humanize",
-    "github.com/ellcrys/abool",
     "github.com/ellcrys/go-ethereum/log",
     "github.com/ellcrys/go-libp2p-crypto",
     "github.com/ellcrys/merkletree",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -117,8 +117,3 @@
 [[constraint]]
   name = "github.com/c-bata/go-prompt"
   revision = "15992ed45e46edd6168d7c8bfda14b700f6b756a"
-
-
-[[constraint]]
-  name = "github.com/ncodes/goblin"
-  version = "0.0.3"

--- a/elldb/types.go
+++ b/elldb/types.go
@@ -66,7 +66,7 @@ func FromKeyValue(key []byte, value []byte) *KVObject {
 	var k, p []byte
 
 	// break down the key to determine the prefix and the original key.
-	parts := bytes.Split(key, []byte(KeyPrefixSeparator))
+	parts := bytes.SplitN(key, []byte(KeyPrefixSeparator), 1)
 
 	// If there are more than 2 parts, it is an invalid key.
 	// If there are only two parts, then the 0 index is the prefix

--- a/elldb/types.go
+++ b/elldb/types.go
@@ -66,7 +66,7 @@ func FromKeyValue(key []byte, value []byte) *KVObject {
 	var k, p []byte
 
 	// break down the key to determine the prefix and the original key.
-	parts := bytes.SplitN(key, []byte(KeyPrefixSeparator), 1)
+	parts := bytes.SplitN(key, []byte(KeyPrefixSeparator), 2)
 
 	// If there are more than 2 parts, it is an invalid key.
 	// If there are only two parts, then the 0 index is the prefix

--- a/makefile
+++ b/makefile
@@ -46,10 +46,10 @@ release-tagged:
 
 # Create a release 
 release-linux:
-	cd $(GOPATH)/src/github.com/ellcrys
-	git checkout ${b}
-	dep ensure -v
-	env GOVERSION=$(GOVERSION) goreleaser release --snapshot --rm-dist -f ".goreleaser.linux.yml"
+	cd $(GOPATH)/src/github.com/ellcrys/elld && \
+	 git checkout ${b} && \
+	 dep ensure -v \
+	 env GOVERSION=$(GOVERSION) goreleaser release --snapshot --rm-dist -f ".goreleaser.linux.yml"
 
 # Build an elld image 
 # use v=version to set Elld release tag

--- a/makefile
+++ b/makefile
@@ -45,12 +45,25 @@ release-tagged:
 	env GOVERSION=$(GOVERSION) goreleaser release --skip-publish --rm-dist
 
 # Build an elld image 
+# use v=version to set Elld release tag
 build: 
-	docker build -t ellcrys/elld .
+ifeq ('${v}','')
+	docker build -t ellcrys/elld --no-cache .
+else
+	docker build --build-arg="version=tags/${v}" -t ellcrys/elld .
+endif
 
 # Rebuild the elld image
+# use v=version to set Elld release tag
 rebuild: 
+ifeq ('${v}','')
 	docker build -t ellcrys/elld --no-cache .
+else
+	docker build --build-arg="version=tags/${v}" -t ellcrys/elld --no-cache .
+endif
+
+build-local:
+	docker build -t ellcrys/elld --no-cache -f ./Dockerfile.local --no-cache .
 	
 # Starts elld client in a docker container
 # with the host data directory (~/.ellcrys) used as volume

--- a/makefile
+++ b/makefile
@@ -48,7 +48,7 @@ release-tagged:
 release-linux:
 	cd $(GOPATH)/src/github.com/ellcrys/elld && \
 	 git checkout ${b} && \
-	 dep ensure -v \
+	 dep ensure -v && \
 	 env GOVERSION=$(GOVERSION) goreleaser release --snapshot --rm-dist -f ".goreleaser.linux.yml"
 
 # Build an elld image 

--- a/makefile
+++ b/makefile
@@ -44,6 +44,13 @@ release:
 release-tagged:
 	env GOVERSION=$(GOVERSION) goreleaser release --skip-publish --rm-dist
 
+# Create a release 
+release-linux:
+	cd $(GOPATH)/src/github.com/ellcrys
+	git checkout ${b}
+	dep ensure -v
+	env GOVERSION=$(GOVERSION) goreleaser release --snapshot --rm-dist -f ".goreleaser.linux.yml"
+
 # Build an elld image 
 # use v=version to set Elld release tag
 build: 
@@ -62,7 +69,7 @@ else
 	docker build --build-arg="version=tags/${v}" -t ellcrys/elld --no-cache .
 endif
 
-build-local:
+build-local-linux: release-linux
 	docker build -t ellcrys/elld --no-cache -f ./Dockerfile.local --no-cache .
 	
 # Starts elld client in a docker container

--- a/miner/miner.go
+++ b/miner/miner.go
@@ -197,11 +197,13 @@ func (m *Miner) RestartWorkers() error {
 // attempts to append the block to a branch.
 func (m *Miner) processBlock(fb *FoundBlock) error {
 
+	m.log.Debug("Update FoundBlock Header")
 	// Update the block header with the found nonce
 	header := fb.Block.GetHeader().Copy()
 	header.SetNonce(util.EncodeNonce(fb.Nonce))
 	fb.Block = fb.Block.ReplaceHeader(header)
 
+	m.log.Debug("Compute Hash")
 	// Compute and set block hash and signature
 	fb.Block.SetHash(fb.Block.ComputeHash())
 	blockSig, _ := core.BlockSign(fb.Block, m.minerKey.PrivKey().Base58())

--- a/miner/miner.go
+++ b/miner/miner.go
@@ -226,17 +226,22 @@ func (m *Miner) onFoundBlock(fb *FoundBlock) {
 	// that has just been solved.
 	m.stopWorkers()
 
+	m.log.Debug("About to Process Found Block")
+
 	// Attempt to process the block.
 	// If it failed, restart the workers
 	if err := m.processBlock(fb); err != nil {
 		m.processing.SetTo(false)
 		m.RestartWorkers()
+		m.log.Debug("Block Processing Failed")
 		return
 	}
+	m.log.Debug("Finished Processing Found Block")
 
 	m.processing.SetTo(false)
 
 	if m.isMining() {
+		m.log.Debug("Restarting Mining")
 
 		// If the new block timestamp is the same as the current
 		// time, we should wait for 1 second so we don't allow
@@ -250,6 +255,7 @@ func (m *Miner) onFoundBlock(fb *FoundBlock) {
 		if err := m.startWorkers(); err != nil {
 			m.log.Debug("Unable to start workers", "Err", err.Error())
 		}
+		m.log.Debug("Restarted Mining")
 	}
 }
 

--- a/miner/miner.go
+++ b/miner/miner.go
@@ -208,8 +208,13 @@ func (m *Miner) processBlock(fb *FoundBlock) error {
 	fb.Block.SetSignature(blockSig)
 
 	errCh := make(chan error)
+	m.log.Debug("Emitting Event")
 	m.event.Emit(core.EventFoundBlock, fb, errCh)
-	return <-errCh
+	m.log.Debug("Emitted Event")
+	r := <-errCh
+	m.log.Debug("Waiting for Event Error")
+
+	return r
 }
 
 // onFoundBlock is called when a worker finds a

--- a/miner/miner.go
+++ b/miner/miner.go
@@ -211,7 +211,7 @@ func (m *Miner) processBlock(fb *FoundBlock) error {
 
 	errCh := make(chan error)
 	m.log.Debug("Emitting Event")
-	m.event.Emit(core.EventFoundBlock, fb, errCh)
+	<-m.event.Emit(core.EventFoundBlock, fb, errCh)
 	m.log.Debug("Emitted Event")
 	r := <-errCh
 	m.log.Debug("Waiting for Event Error")

--- a/miner/miner.go
+++ b/miner/miner.go
@@ -8,8 +8,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/ellcrys/abool"
-
 	"github.com/ellcrys/elld/config"
 	"github.com/ellcrys/elld/crypto"
 	"github.com/ellcrys/elld/miner/blakimoto"
@@ -36,6 +34,10 @@ var (
 // mine block for processing.
 type Miner struct {
 	sync.RWMutex
+
+	// processMtx is a mutex for processing
+	// blocks found by a worker
+	processMtx *sync.Mutex
 
 	// numThreads is the number of threads
 	// running the pow computation
@@ -71,7 +73,7 @@ type Miner struct {
 
 	// processing indicates that a block is being
 	// processed for inclusion in a branch
-	processing *abool.AtomicBool
+	processing bool
 
 	// lastFoundBlockHash is the hash of the last
 	// block found by this miner
@@ -96,7 +98,7 @@ func NewMiner(mineKey *crypto.Key, blockMaker types.BlockMaker,
 		blakimoto:  blakimoto.ConfiguredBlakimoto(blakimoto.Mode(cfg.Miner.Mode), log),
 		hashrate:   metrics.NewMeter(),
 		done:       make(chan bool),
-		processing: abool.New(),
+		processMtx: &sync.Mutex{},
 	}
 }
 
@@ -213,14 +215,26 @@ func (m *Miner) processBlock(fb *FoundBlock) error {
 	return <-errCh
 }
 
+// isProcessing checks whether a mined block
+// is being processed.
+func (m *Miner) isProcessing() bool {
+	m.processMtx.Lock()
+	defer m.processMtx.Unlock()
+	return m.processing
+}
+
 // onFoundBlock is called when a worker finds a
 // valid nonce for the current proposed block.
 func (m *Miner) onFoundBlock(fb *FoundBlock) {
+	m.processMtx.Lock()
+	defer m.processMtx.Unlock()
 
-	if !m.processing.SetToIf(false, true) {
+	if m.processing {
 		m.log.Debug("Rejected a block. Currently processing a winner")
 		return
 	}
+
+	m.processing = true
 
 	// Stop all workers who are currently
 	// trying to solve PoW for the current round
@@ -230,12 +244,12 @@ func (m *Miner) onFoundBlock(fb *FoundBlock) {
 	// Attempt to process the block.
 	// If it failed, restart the workers
 	if err := m.processBlock(fb); err != nil {
-		m.processing.SetTo(false)
+		m.processing = false
 		m.RestartWorkers()
 		return
 	}
 
-	m.processing.SetTo(false)
+	m.processing = false
 
 	if m.isMining() {
 
@@ -260,7 +274,9 @@ func (m *Miner) handleWorkersEvents() {
 	for {
 		select {
 		case evt := <-m.iEvent.Once(EventWorkerFoundBlock, emitter.Sync):
-			m.onFoundBlock(evt.Args[0].(*FoundBlock))
+			if !m.isProcessing() {
+				m.onFoundBlock(evt.Args[0].(*FoundBlock))
+			}
 		}
 	}
 }

--- a/node/block_manager.go
+++ b/node/block_manager.go
@@ -85,7 +85,9 @@ func (bm *BlockManager) Handle() {
 		case core.EventFoundBlock:
 			errCh := evt.Args[1].(chan error)
 			go func(errCh chan error) {
+				bm.log.Debug("Handling Mined Block")
 				errCh <- bm.handleMined(evt.Args[0].(*miner.FoundBlock))
+				bm.log.Debug("Finished Handling Mined Block")
 			}(errCh)
 
 		case core.EventNewBlock:

--- a/node/block_manager.go
+++ b/node/block_manager.go
@@ -80,17 +80,13 @@ func (bm *BlockManager) SetTxPool(tp types.TxPool) {
 func (bm *BlockManager) Handle() {
 	go func() {
 		for {
-			evt := <-bm.evt.Once("*")
-			switch evt.OriginalTopic {
-
-			case core.EventFoundBlock:
-				go func(errCh chan error) {
-					bm.log.Debug("Received FoundBlock Event")
-					bm.log.Debug("Handling Mined Block")
-					errCh <- bm.handleMined(evt.Args[0].(*miner.FoundBlock))
-					bm.log.Debug("Finished Handling Mined Block")
-				}(evt.Args[1].(chan error))
-			}
+			evt := <-bm.evt.Once(core.EventFoundBlock)
+			go func(errCh chan error) {
+				bm.log.Debug("Received FoundBlock Event")
+				bm.log.Debug("Handling Mined Block")
+				errCh <- bm.handleMined(evt.Args[0].(*miner.FoundBlock))
+				bm.log.Debug("Finished Handling Mined Block")
+			}(evt.Args[1].(chan error))
 		}
 	}()
 

--- a/node/block_manager.go
+++ b/node/block_manager.go
@@ -83,13 +83,12 @@ func (bm *BlockManager) Handle() {
 		switch evt.OriginalTopic {
 
 		case core.EventFoundBlock:
-			bm.log.Debug("Received FoundBlock Event")
-			errCh := evt.Args[1].(chan error)
 			go func(errCh chan error) {
+				bm.log.Debug("Received FoundBlock Event")
 				bm.log.Debug("Handling Mined Block")
 				errCh <- bm.handleMined(evt.Args[0].(*miner.FoundBlock))
 				bm.log.Debug("Finished Handling Mined Block")
-			}(errCh)
+			}(evt.Args[1].(chan error))
 
 		case core.EventNewBlock:
 			go bm.handleAppendedBlock(evt.Args[0].(*core.Block))

--- a/node/block_manager.go
+++ b/node/block_manager.go
@@ -100,15 +100,14 @@ func (bm *BlockManager) Handle() {
 			go bm.handleProcessBlock(evt.Args[0].(*core.Block))
 
 		case core.EventPeerChainInfo:
-			peerChainInfo := evt.Args[0].(*types.SyncPeerChainInfo)
-			if bm.isSyncCandidate(peerChainInfo) {
-				bm.addSyncCandidate(peerChainInfo)
-				go func() {
+			go func(peerChainInfo *types.SyncPeerChainInfo) {
+				if bm.isSyncCandidate(peerChainInfo) {
+					bm.addSyncCandidate(peerChainInfo)
 					if bm.sync() == nil {
 						bm.log.Info("Block synchronization complete")
 					}
-				}()
-			}
+				}
+			}(evt.Args[0].(*types.SyncPeerChainInfo))
 		}
 	}
 }

--- a/node/block_manager.go
+++ b/node/block_manager.go
@@ -83,6 +83,7 @@ func (bm *BlockManager) Handle() {
 		switch evt.OriginalTopic {
 
 		case core.EventFoundBlock:
+			bm.log.Debug("Received FoundBlock Event")
 			errCh := evt.Args[1].(chan error)
 			go func(errCh chan error) {
 				bm.log.Debug("Handling Mined Block")


### PR DESCRIPTION
# Commit Summary

### Node
* BlockManager now handles events in separate goroutines and binds to their target name. 

### Miner
* Introduced a process mutex for synchronizing access to the state created/accessed during the processing of newly found blocks. 

### ElldDB
* Split on the first occurrence of the key prefix separator. 

### Others
* Added new docker file `Dockerfile.local` for creating Elld docker container using a local executable.
* Added support for setting release tag when building Elld docker container.
* Removed `elld-race` goreleaser build stanza.
* Updated Gopkg contents.
