### PR TITLE
Block & Transaction Broadcast Improvements

### DIFF
--- a/blockchain/blockchain.go
+++ b/blockchain/blockchain.go
@@ -698,11 +698,9 @@ func (b *Blockchain) SelectTransactions(maxSize int64) (selectedTxs []types.Tran
 		cache = append(cache, tx)
 	}
 
-	// put the cached transactions
-	// back to the pool. But this time,
-	// we do it silently (no events, etc)
+	// put the cached transactions back to the pool
 	for _, tx := range cache {
-		b.txPool.PutSilently(tx)
+		b.txPool.Put(tx)
 	}
 
 	return

--- a/blockchain/reorg_test.go
+++ b/blockchain/reorg_test.go
@@ -68,7 +68,7 @@ var _ = Describe("ReOrg", func() {
 		BeforeEach(func() {
 			genesisChainBlock2 := MakeTestBlock(bc, genesisChain, &types.GenerateBlockParams{
 				Transactions: []types.Transaction{
-					core.NewTx(core.TxTypeBalance, 1, util.String(receiver.Addr()), sender, "1", "2.5", 1532730724),
+					core.NewTx(core.TxTypeBalance, 1, util.String(receiver.Addr()), sender, "1", "2.5", time.Now().Unix()),
 				},
 				Creator:                 sender,
 				Nonce:                   util.EncodeNonce(1),
@@ -90,7 +90,7 @@ var _ = Describe("ReOrg", func() {
 
 					chainABlock1 := MakeTestBlock(bc, genesisChain, &types.GenerateBlockParams{
 						Transactions: []types.Transaction{
-							core.NewTx(core.TxTypeAlloc, 1, util.String(sender.Addr()), sender, "1", "2.5", 1532730724),
+							core.NewTx(core.TxTypeAlloc, 1, util.String(sender.Addr()), sender, "1", "2.5", time.Now().Unix()),
 						},
 						Creator:                 sender,
 						Nonce:                   util.EncodeNonce(1),
@@ -119,7 +119,7 @@ var _ = Describe("ReOrg", func() {
 
 					chainBBlock1 := MakeTestBlock(bc, genesisChain, &types.GenerateBlockParams{
 						Transactions: []types.Transaction{
-							core.NewTx(core.TxTypeAlloc, 1, util.String(sender.Addr()), sender, "1", "2.5", 1532730726),
+							core.NewTx(core.TxTypeAlloc, 1, util.String(sender.Addr()), sender, "1", "2.5", time.Now().Unix()),
 						},
 						Creator:                 sender,
 						Nonce:                   util.EncodeNonce(1),
@@ -152,7 +152,7 @@ var _ = Describe("ReOrg", func() {
 
 					chainABlock1 := MakeTestBlock(bc, genesisChain, &types.GenerateBlockParams{
 						Transactions: []types.Transaction{
-							core.NewTx(core.TxTypeAlloc, 1, util.String(sender.Addr()), sender, "1", "2.5", 1532730724),
+							core.NewTx(core.TxTypeAlloc, 1, util.String(sender.Addr()), sender, "1", "2.5", time.Now().Unix()),
 						},
 						Creator:                 sender,
 						Nonce:                   util.EncodeNonce(1),
@@ -186,7 +186,7 @@ var _ = Describe("ReOrg", func() {
 
 					chainABlock1 := MakeTestBlock(bc, genesisChain, &types.GenerateBlockParams{
 						Transactions: []types.Transaction{
-							core.NewTx(core.TxTypeAlloc, 1, util.String(sender.Addr()), sender, "1", "2.5", 1532730724),
+							core.NewTx(core.TxTypeAlloc, 1, util.String(sender.Addr()), sender, "1", "2.5", time.Now().Unix()),
 						},
 						Creator:                 sender,
 						Nonce:                   util.EncodeNonce(1),
@@ -223,8 +223,8 @@ var _ = Describe("ReOrg", func() {
 			// genesis block 2
 			genesisB2 := MakeTestBlock(bc, genesisChain, &types.GenerateBlockParams{
 				Transactions: []types.Transaction{
-					core.NewTx(core.TxTypeBalance, 1, util.String(receiver.Addr()), sender, "1", "2.5", 1532730723),
-					core.NewTx(core.TxTypeAlloc, 1, util.String(sender.Addr()), sender, "2.5", "0", 1532730723),
+					core.NewTx(core.TxTypeBalance, 1, util.String(receiver.Addr()), sender, "1", "2.5", time.Now().Unix()),
+					core.NewTx(core.TxTypeAlloc, 1, util.String(sender.Addr()), sender, "2.5", "0", time.Now().Unix()),
 				},
 				Creator:    sender,
 				Nonce:      util.EncodeNonce(1),
@@ -233,8 +233,8 @@ var _ = Describe("ReOrg", func() {
 
 			forkChainB2 := MakeTestBlock(bc, genesisChain, &types.GenerateBlockParams{
 				Transactions: []types.Transaction{
-					core.NewTx(core.TxTypeBalance, 1, util.String(receiver.Addr()), sender, "1", "2.5", 1532730724),
-					core.NewTx(core.TxTypeAlloc, 1, util.String(sender.Addr()), sender, "2.5", "0", 1532730724),
+					core.NewTx(core.TxTypeBalance, 1, util.String(receiver.Addr()), sender, "1", "2.5", time.Now().Unix()),
+					core.NewTx(core.TxTypeAlloc, 1, util.String(sender.Addr()), sender, "2.5", "0", time.Now().Unix()+1),
 				},
 				Creator:    sender,
 				Nonce:      util.EncodeNonce(1),
@@ -252,8 +252,8 @@ var _ = Describe("ReOrg", func() {
 			// genesis block 3
 			genesisB3 := MakeTestBlock(bc, genesisChain, &types.GenerateBlockParams{
 				Transactions: []types.Transaction{
-					core.NewTx(core.TxTypeBalance, 2, util.String(receiver.Addr()), sender, "1", "2.5", 1532730725),
-					core.NewTx(core.TxTypeAlloc, 2, util.String(sender.Addr()), sender, "2.5", "0", 1532730725),
+					core.NewTx(core.TxTypeBalance, 2, util.String(receiver.Addr()), sender, "1", "2.5", time.Now().Unix()),
+					core.NewTx(core.TxTypeAlloc, 2, util.String(sender.Addr()), sender, "2.5", "0", time.Now().Unix()),
 				},
 				Creator:    sender,
 				Nonce:      util.EncodeNonce(1),
@@ -265,8 +265,8 @@ var _ = Describe("ReOrg", func() {
 			// genesis block 4
 			genesisB4 := MakeTestBlock(bc, genesisChain, &types.GenerateBlockParams{
 				Transactions: []types.Transaction{
-					core.NewTx(core.TxTypeBalance, 3, util.String(receiver.Addr()), sender, "1", "2.5", 1532730726),
-					core.NewTx(core.TxTypeAlloc, 3, util.String(sender.Addr()), sender, "2.5", "0", 1532730726),
+					core.NewTx(core.TxTypeBalance, 3, util.String(receiver.Addr()), sender, "1", "2.5", time.Now().Unix()),
+					core.NewTx(core.TxTypeAlloc, 3, util.String(sender.Addr()), sender, "2.5", "0", time.Now().Unix()),
 				},
 				Creator:    sender,
 				Nonce:      util.EncodeNonce(1),
@@ -349,8 +349,8 @@ var _ = Describe("ReOrg", func() {
 			// genesis block 2
 			genesisB2 := MakeTestBlock(bc, genesisChain, &types.GenerateBlockParams{
 				Transactions: []types.Transaction{
-					core.NewTx(core.TxTypeBalance, 1, util.String(receiver.Addr()), sender, "1", "2.5", 1532730723),
-					core.NewTx(core.TxTypeAlloc, 1, util.String(sender.Addr()), sender, "2.5", "0", 1532730723),
+					core.NewTx(core.TxTypeBalance, 1, util.String(receiver.Addr()), sender, "1", "2.5", time.Now().Unix()),
+					core.NewTx(core.TxTypeAlloc, 1, util.String(sender.Addr()), sender, "2.5", "0", time.Now().Unix()-1),
 				},
 				Creator:    sender,
 				Nonce:      util.EncodeNonce(1),
@@ -360,8 +360,8 @@ var _ = Describe("ReOrg", func() {
 			// forked chain block 2
 			forkChainB2 := MakeTestBlock(bc, genesisChain, &types.GenerateBlockParams{
 				Transactions: []types.Transaction{
-					core.NewTx(core.TxTypeBalance, 1, util.String(receiver.Addr()), sender, "1", "2.5", 1532730724),
-					core.NewTx(core.TxTypeAlloc, 1, util.String(sender.Addr()), sender, "2.5", "0", 1532730724),
+					core.NewTx(core.TxTypeBalance, 1, util.String(receiver.Addr()), sender, "1", "2.5", time.Now().Unix()),
+					core.NewTx(core.TxTypeAlloc, 1, util.String(sender.Addr()), sender, "2.5", "0", time.Now().Unix()-2),
 				},
 				Creator:    sender,
 				Nonce:      util.EncodeNonce(1),
@@ -380,8 +380,8 @@ var _ = Describe("ReOrg", func() {
 			// forked chain block 3
 			forkChainB3 := MakeTestBlock(bc, forkedChain, &types.GenerateBlockParams{
 				Transactions: []types.Transaction{
-					core.NewTx(core.TxTypeBalance, 2, util.String(receiver.Addr()), sender, "1", "2.5", 1532730725),
-					core.NewTx(core.TxTypeAlloc, 0, util.String(sender.Addr()), sender, "2.5", "0", 1532730725),
+					core.NewTx(core.TxTypeBalance, 2, util.String(receiver.Addr()), sender, "1", "2.5", time.Now().Unix()),
+					core.NewTx(core.TxTypeAlloc, 0, util.String(sender.Addr()), sender, "2.5", "0", time.Now().Unix()-1),
 				},
 				Creator:    sender,
 				Nonce:      util.EncodeNonce(1),
@@ -393,8 +393,8 @@ var _ = Describe("ReOrg", func() {
 			// forked chain block 4
 			forkedChainB4 := MakeTestBlock(bc, forkedChain, &types.GenerateBlockParams{
 				Transactions: []types.Transaction{
-					core.NewTx(core.TxTypeBalance, 3, util.String(receiver.Addr()), sender, "1", "2.5", 1532730726),
-					core.NewTx(core.TxTypeAlloc, 3, util.String(sender.Addr()), sender, "2.5", "0", 1532730726),
+					core.NewTx(core.TxTypeBalance, 3, util.String(receiver.Addr()), sender, "1", "2.5", time.Now().Unix()),
+					core.NewTx(core.TxTypeAlloc, 3, util.String(sender.Addr()), sender, "2.5", "0", time.Now().Unix()),
 				},
 				Creator:    sender,
 				Nonce:      util.EncodeNonce(1),

--- a/blockchain/testutil/block_maker.go
+++ b/blockchain/testutil/block_maker.go
@@ -21,7 +21,7 @@ func MakeTestBlock(bc types.Blockchain, chain types.Chainer, gp *types.GenerateB
 	}
 	if !gp.NoPoolAdditionInTest && bc.GetTxPool() != nil {
 		for _, tx := range blk.GetTransactions() {
-			bc.GetTxPool().PutSilently(tx)
+			bc.GetTxPool().Put(tx)
 		}
 	}
 	return blk

--- a/blockchain/transaction_validator_test.go
+++ b/blockchain/transaction_validator_test.go
@@ -343,8 +343,8 @@ var _ = Describe("TransactionValidator", func() {
 			BeforeEach(func() {
 				block2 = MakeTestBlock(bc, genesisChain, &types.GenerateBlockParams{
 					Transactions: []types.Transaction{
-						core.NewTx(core.TxTypeBalance, 1, util.String(receiver.Addr()), sender, "1", "2.5", 1532730723),
-						core.NewTx(core.TxTypeAlloc, 1, util.String(sender.Addr()), sender, "2.5", "0", 1532730725),
+						core.NewTx(core.TxTypeBalance, 1, util.String(receiver.Addr()), sender, "1", "2.5", time.Now().Unix()),
+						core.NewTx(core.TxTypeAlloc, 1, util.String(sender.Addr()), sender, "2.5", "0", time.Now().Unix()+1),
 					},
 					Creator:    sender,
 					Nonce:      util.EncodeNonce(1),

--- a/blockchain/txpool/txpool.go
+++ b/blockchain/txpool/txpool.go
@@ -4,8 +4,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/olebedev/emitter"
-
 	"github.com/ellcrys/elld/params"
 	"github.com/ellcrys/elld/types"
 	"github.com/ellcrys/elld/types/core"
@@ -14,9 +12,8 @@ import (
 
 // TxPool stores transactions.
 type TxPool struct {
-	sync.RWMutex                  // general mutex
-	container    *TxContainer     // transaction queue
-	event        *emitter.Emitter // event emitter
+	sync.RWMutex              // general mutex
+	container    *TxContainer // transaction queue
 }
 
 // New creates a new instance of TxPool.
@@ -25,13 +22,7 @@ type TxPool struct {
 func New(cap int64) *TxPool {
 	tp := new(TxPool)
 	tp.container = newTxContainer(cap)
-	tp.event = &emitter.Emitter{}
 	return tp
-}
-
-// SetEventEmitter sets the event emitter
-func (tp *TxPool) SetEventEmitter(ee *emitter.Emitter) {
-	tp.event = ee
 }
 
 // Remove removes transactions
@@ -51,9 +42,6 @@ func (tp *TxPool) Put(tx types.Transaction) error {
 		return err
 	}
 
-	// Emit an event about the accepted transaction
-	tp.event.Emit(core.EventNewTransaction, tx)
-
 	tp.clean()
 
 	return nil
@@ -68,19 +56,6 @@ func (tp *TxPool) clean() {
 		}
 		return false
 	})
-}
-
-// PutSilently is like Put but it does not
-// emit an event on success.
-func (tp *TxPool) PutSilently(tx types.Transaction) error {
-	tp.Lock()
-	defer tp.Unlock()
-
-	if err := tp.addTx(tx); err != nil {
-		return err
-	}
-
-	return nil
 }
 
 // addTx adds a transaction to the queue.

--- a/blockchain/txpool/txpool_test.go
+++ b/blockchain/txpool/txpool_test.go
@@ -58,21 +58,6 @@ var _ = Describe("TxPool", func() {
 			Expect(err).To(BeNil())
 			Expect(tp.container.Size()).To(Equal(int64(1)))
 		})
-
-		It("should emit core.EventNewTransaction", func() {
-			tp := New(1)
-			a, _ := crypto.NewKey(nil)
-			tx := core.NewTransaction(core.TxTypeBalance, 1, "something", util.String(a.PubKey().Base58()), "0", "0", time.Now().Unix())
-			go func() {
-				sig, _ := core.TxSign(tx, a.PrivKey().Base58())
-				tx.Sig = sig
-				err := tp.Put(tx)
-				Expect(err).To(BeNil())
-				Expect(tp.container.Size()).To(Equal(int64(1)))
-			}()
-			event := <-tp.event.Once(core.EventNewTransaction)
-			Expect(event.Args[0]).To(Equal(tx))
-		})
 	})
 
 	Describe(".HasTxWithSameNonce", func() {

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -32,10 +32,10 @@ import (
 
 var (
 	boostrapAddresses = []string{
-		"ellcrys://12D3KooWKAEhd4DXGPeN71FeSC1ih86Ym2izpoPueaCrME8xu8UM@n1.ellnode.com:9000",
-		"ellcrys://12D3KooWD276x1ieiV9cmtBdZeVLN5LtFrnUS6AT2uAkHHFNADRx@n2.ellnode.com:9000",
-		"ellcrys://12D3KooWDdUZny1FagkUregeNQUb8PB6Vg1LMWcwWquqovm7QADb@n3.ellnode.com:9000",
-		"ellcrys://12D3KooWDWA4g8EXWWBSbWbefSu2RGttNh1QDpQYA7nCDnbVADP1@n4.ellnode.com:9000",
+		// "ellcrys://12D3KooWKAEhd4DXGPeN71FeSC1ih86Ym2izpoPueaCrME8xu8UM@n1.ellnode.com:9000",
+		// "ellcrys://12D3KooWD276x1ieiV9cmtBdZeVLN5LtFrnUS6AT2uAkHHFNADRx@n2.ellnode.com:9000",
+		// "ellcrys://12D3KooWDdUZny1FagkUregeNQUb8PB6Vg1LMWcwWquqovm7QADb@n3.ellnode.com:9000",
+		// "ellcrys://12D3KooWDWA4g8EXWWBSbWbefSu2RGttNh1QDpQYA7nCDnbVADP1@n4.ellnode.com:9000",
 	}
 )
 
@@ -232,7 +232,6 @@ func start(cmd *cobra.Command, args []string, startConsole bool) (*node.Node, *r
 
 	// Configure transactions pool and assign to node
 	pool := txpool.New(params.PoolCapacity)
-	pool.SetEventEmitter(event)
 	n.SetTxsPool(pool)
 
 	// Add hardcoded bootstrap addresses
@@ -266,11 +265,16 @@ func start(cmd *cobra.Command, args []string, startConsole bool) (*node.Node, *r
 	n.SetBlockchain(bChain)
 	n.SetEventEmitter(event)
 
-	// Set block manager's references
+	// Setup block manager
 	bm := node.NewBlockManager(n)
 	bm.SetMiner(miner)
-	bm.SetTxPool(pool)
+	go bm.Manage()
 	n.SetBlockManager(bm)
+
+	// Set transaction manager
+	tm := node.NewTxManager(n)
+	go tm.Manage()
+	n.SetTxManager(tm)
 
 	// power up the blockchain manager
 	if err := bChain.Up(); err != nil {
@@ -279,8 +283,6 @@ func start(cmd *cobra.Command, args []string, startConsole bool) (*node.Node, *r
 
 	// Start the block manager and the node
 	n.Start()
-
-	go bm.Handle()
 
 	// Initialized and start the miner if enabled via the cli flag.
 	miner.SetNumThreads(numMiners)

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -31,11 +31,11 @@ import (
 )
 
 var (
-	boostrapAddresses = []string{
-		// "ellcrys://12D3KooWKAEhd4DXGPeN71FeSC1ih86Ym2izpoPueaCrME8xu8UM@n1.ellnode.com:9000",
-		// "ellcrys://12D3KooWD276x1ieiV9cmtBdZeVLN5LtFrnUS6AT2uAkHHFNADRx@n2.ellnode.com:9000",
-		// "ellcrys://12D3KooWDdUZny1FagkUregeNQUb8PB6Vg1LMWcwWquqovm7QADb@n3.ellnode.com:9000",
-		// "ellcrys://12D3KooWDWA4g8EXWWBSbWbefSu2RGttNh1QDpQYA7nCDnbVADP1@n4.ellnode.com:9000",
+	seedAddresses = []string{
+		"ellcrys://12D3KooWKAEhd4DXGPeN71FeSC1ih86Ym2izpoPueaCrME8xu8UM@n1.ellnode.com:9000",
+		"ellcrys://12D3KooWD276x1ieiV9cmtBdZeVLN5LtFrnUS6AT2uAkHHFNADRx@n2.ellnode.com:9000",
+		"ellcrys://12D3KooWDdUZny1FagkUregeNQUb8PB6Vg1LMWcwWquqovm7QADb@n3.ellnode.com:9000",
+		"ellcrys://12D3KooWDWA4g8EXWWBSbWbefSu2RGttNh1QDpQYA7nCDnbVADP1@n4.ellnode.com:9000",
 	}
 )
 
@@ -235,7 +235,7 @@ func start(cmd *cobra.Command, args []string, startConsole bool) (*node.Node, *r
 	n.SetTxsPool(pool)
 
 	// Add hardcoded bootstrap addresses
-	if err := n.AddAddresses(boostrapAddresses, true); err != nil {
+	if err := n.AddAddresses(seedAddresses, true); err != nil {
 		log.Fatal("%s", err)
 	}
 

--- a/config/protocol_versions.go
+++ b/config/protocol_versions.go
@@ -62,6 +62,9 @@ type ProtocolVersions struct {
 	// Tx is the message version for handing wire.Transaction messages
 	Tx string
 
+	// BlockInfo is the message version for handling wire.BlockInfo messages
+	BlockInfo string
+
 	// BlockBody is the message version for handling wire.BlockBody messages
 	BlockBody string
 

--- a/node/api.go
+++ b/node/api.go
@@ -254,7 +254,7 @@ func (n *Node) apiSend(arg interface{}) *jsonrpc.Response {
 	}
 
 	// Attempt to add the transaction to the pool
-	if err := n.AddTransaction(&tx); err != nil {
+	if err := n.txManager.AddTx(&tx); err != nil {
 		return jsonrpc.Error(types.ErrCodeTxFailed, err.Error(), nil)
 	}
 

--- a/node/block_manager.go
+++ b/node/block_manager.go
@@ -158,7 +158,7 @@ func (bm *BlockManager) handleMined(fb *miner.FoundBlock) error {
 // relayAppendedBlock a block to connected peers
 func (bm *BlockManager) relayAppendedBlock(b types.Block) {
 	if b.GetNumber() > 1 {
-		bm.engine.Gossip().RelayBlock(b, bm.engine.PM().GetConnectedPeers())
+		bm.engine.Gossip().BroadcastBlock(b, bm.engine.PM().GetConnectedPeers())
 	}
 }
 

--- a/node/block_manager.go
+++ b/node/block_manager.go
@@ -38,10 +38,7 @@ type BlockManager struct {
 	// miner is CPU miner
 	miner *miner.Miner
 
-	// txPool is the transaction pool
-	txPool types.TxPool
-
-	// peerMgr is the client peer manager
+	// engine is the node's instance
 	engine *Node
 
 	// syncCandidate are candidate peers to
@@ -71,13 +68,8 @@ func (bm *BlockManager) SetMiner(m *miner.Miner) {
 	bm.miner = m
 }
 
-// SetTxPool sets a reference of the transaction pool
-func (bm *BlockManager) SetTxPool(tp types.TxPool) {
-	bm.txPool = tp
-}
-
-// Handle handles all incoming block related events.
-func (bm *BlockManager) Handle() {
+// Manage handles all incoming block related events.
+func (bm *BlockManager) Manage() {
 
 	go func() {
 		for evt := range bm.evt.Once(core.EventFoundBlock) {
@@ -175,7 +167,7 @@ func (bm *BlockManager) relayAppendedBlock(b types.Block) {
 func (bm *BlockManager) handleAppendedBlock(b types.Block) {
 
 	// Remove the blocks transactions from the pool.
-	bm.txPool.Remove(b.GetTransactions()...)
+	bm.engine.txsPool.Remove(b.GetTransactions()...)
 
 	// Restart miner workers.
 	bm.miner.RestartWorkers()

--- a/node/block_manager.go
+++ b/node/block_manager.go
@@ -80,32 +80,32 @@ func (bm *BlockManager) SetTxPool(tp types.TxPool) {
 func (bm *BlockManager) Handle() {
 
 	go func() {
-		for evt := range bm.evt.On(core.EventFoundBlock) {
+		for evt := range bm.evt.Once(core.EventFoundBlock) {
 			errCh := evt.Args[1].(chan error)
 			errCh <- bm.handleMined(evt.Args[0].(*miner.FoundBlock))
 		}
 	}()
 
 	go func() {
-		for evt := range bm.evt.On(core.EventNewBlock) {
+		for evt := range bm.evt.Once(core.EventNewBlock) {
 			bm.handleAppendedBlock(evt.Args[0].(*core.Block))
 		}
 	}()
 
 	go func() {
-		for evt := range bm.evt.On(core.EventOrphanBlock) {
+		for evt := range bm.evt.Once(core.EventOrphanBlock) {
 			bm.handleOrphan(evt.Args[0].(*core.Block))
 		}
 	}()
 
 	go func() {
-		for evt := range bm.evt.On(core.EventProcessBlock) {
+		for evt := range bm.evt.Once(core.EventProcessBlock) {
 			bm.handleProcessBlock(evt.Args[0].(*core.Block))
 		}
 	}()
 
 	go func() {
-		for evt := range bm.evt.On(core.EventPeerChainInfo) {
+		for evt := range bm.evt.Once(core.EventPeerChainInfo) {
 			peerChainInfo := evt.Args[0].(*types.SyncPeerChainInfo)
 			if bm.isSyncCandidate(peerChainInfo) {
 				bm.addSyncCandidate(peerChainInfo)

--- a/node/gossip/block.go
+++ b/node/gossip/block.go
@@ -25,7 +25,7 @@ func makeOrphanBlockHistoryKey(blockHash util.Hash,
 
 // RelayBlock sends a given block to remote peers.
 // The block is encapsulated in a BlockBody message.
-func (g *GossipManager) RelayBlock(block types.Block, remotePeers []core.Engine) error {
+func (g *Manager) RelayBlock(block types.Block, remotePeers []core.Engine) error {
 
 	g.log.Debug("Relaying block to peer(s)", "BlockNo", block.GetNumber(),
 		"NumPeers", len(remotePeers))
@@ -70,7 +70,7 @@ func (g *GossipManager) RelayBlock(block types.Block, remotePeers []core.Engine)
 // BlockBody messages contain information about a
 // block. It will attempt to process the received
 // block.
-func (g *GossipManager) OnBlockBody(s net.Stream, rp core.Engine) error {
+func (g *Manager) OnBlockBody(s net.Stream, rp core.Engine) error {
 
 	defer s.Close()
 
@@ -109,7 +109,7 @@ func (g *GossipManager) OnBlockBody(s net.Stream, rp core.Engine) error {
 // The block's validation context is set to ContextBlockSync
 // which cause the transactions to not be required to exist
 // in the transaction pool.
-func (g *GossipManager) RequestBlock(rp core.Engine, blockHash util.Hash) error {
+func (g *Manager) RequestBlock(rp core.Engine, blockHash util.Hash) error {
 
 	historyKey := makeOrphanBlockHistoryKey(blockHash, rp)
 	if g.engine.GetHistory().HasMulti(historyKey...) {
@@ -151,7 +151,7 @@ func (g *GossipManager) RequestBlock(rp core.Engine, blockHash util.Hash) error 
 // OnRequestBlock handles RequestBlock message.
 // A RequestBlock message includes information
 // a bout a block that a remote node needs.
-func (g *GossipManager) OnRequestBlock(s net.Stream, rp core.Engine) error {
+func (g *Manager) OnRequestBlock(s net.Stream, rp core.Engine) error {
 
 	defer s.Close()
 
@@ -216,7 +216,7 @@ func (g *GossipManager) OnRequestBlock(s net.Stream, rp core.Engine) error {
 //
 // If the locators is not provided via the locator argument,
 // they will be collected from the main chain.
-func (g *GossipManager) SendGetBlockHashes(rp core.Engine,
+func (g *Manager) SendGetBlockHashes(rp core.Engine,
 	locators []util.Hash, seek util.Hash) (*core.BlockHashes, error) {
 
 	rpID := rp.ShortID()
@@ -275,7 +275,7 @@ func (g *GossipManager) SendGetBlockHashes(rp core.Engine,
 // not the same as its main chain (a branch), it will
 // send block hashes starting from the root parent block (oldest
 // ancestor) which exists on the main chain.
-func (g *GossipManager) OnGetBlockHashes(s net.Stream, rp core.Engine) error {
+func (g *Manager) OnGetBlockHashes(s net.Stream, rp core.Engine) error {
 
 	defer s.Close()
 
@@ -372,7 +372,7 @@ send:
 
 // SendGetBlockBodies sends a GetBlockBodies message
 // requesting for whole bodies of a collection blocks.
-func (g *GossipManager) SendGetBlockBodies(rp core.Engine, hashes []util.Hash) (*core.BlockBodies, error) {
+func (g *Manager) SendGetBlockBodies(rp core.Engine, hashes []util.Hash) (*core.BlockBodies, error) {
 
 	rpID := rp.ShortID()
 	g.log.Debug("Requesting block bodies", "PeerID", rpID, "NumHashes", len(hashes))
@@ -408,7 +408,7 @@ func (g *GossipManager) SendGetBlockBodies(rp core.Engine, hashes []util.Hash) (
 }
 
 // OnGetBlockBodies handles GetBlockBodies requests
-func (g *GossipManager) OnGetBlockBodies(s net.Stream, rp core.Engine) error {
+func (g *Manager) OnGetBlockBodies(s net.Stream, rp core.Engine) error {
 	defer s.Close()
 
 	// Read the message

--- a/node/gossip/block_test.go
+++ b/node/gossip/block_test.go
@@ -49,7 +49,7 @@ var _ = Describe("Block", func() {
 		closeNode(rp)
 	})
 
-	Describe(".RelayBlock", func() {
+	Describe(".BroadcastBlock", func() {
 		Context("when block is successfully relayed to a remote peer", func() {
 
 			var block types.Block
@@ -63,7 +63,7 @@ var _ = Describe("Block", func() {
 			It("remote peer must emit core.EventProcessBlock and core.EventBlockProcessed", func(done Done) {
 				wait := make(chan bool)
 
-				err := lp.Gossip().RelayBlock(block, []core.Engine{rp})
+				err := lp.Gossip().BroadcastBlock(block, []core.Engine{rp})
 				Expect(err).To(BeNil())
 
 				go func() {
@@ -97,7 +97,7 @@ var _ = Describe("Block", func() {
 			It("should return error about the missing transaction in the pool", func(done Done) {
 				wait := make(chan bool)
 
-				err := lp.Gossip().RelayBlock(block, []core.Engine{rp})
+				err := lp.Gossip().BroadcastBlock(block, []core.Engine{rp})
 				Expect(err).To(BeNil())
 
 				go func() {
@@ -141,7 +141,7 @@ var _ = Describe("Block", func() {
 			Specify("relayed block must be processed by the remote peer", func(done Done) {
 				wait := make(chan bool)
 
-				err := lp.Gossip().RelayBlock(block, []core.Engine{rp})
+				err := lp.Gossip().BroadcastBlock(block, []core.Engine{rp})
 				Expect(err).To(BeNil())
 
 				go func() {
@@ -185,7 +185,7 @@ var _ = Describe("Block", func() {
 			It("should emit core.EventOrphanBlock", func(done Done) {
 				wait := make(chan bool)
 
-				err := lp.Gossip().RelayBlock(block3, []core.Engine{rp})
+				err := lp.Gossip().BroadcastBlock(block3, []core.Engine{rp})
 				Expect(err).To(BeNil())
 
 				go func() {

--- a/node/gossip/block_test.go
+++ b/node/gossip/block_test.go
@@ -57,7 +57,7 @@ var _ = Describe("Block", func() {
 			BeforeEach(func() {
 				block = MakeBlockWithSingleTx(lp.GetBlockchain(), lp.GetBlockchain().GetBestChain(), sender, sender, 1)
 				bm := node.NewBlockManager(rp)
-				go bm.Handle()
+				go bm.Manage()
 			})
 
 			It("remote peer must emit core.EventProcessBlock and core.EventBlockProcessed", func(done Done) {
@@ -91,7 +91,7 @@ var _ = Describe("Block", func() {
 			BeforeEach(func() {
 				block = MakeBlockWithSingleTx(lp.GetBlockchain(), lp.GetBlockchain().GetBestChain(), sender, sender, 1)
 				bm := node.NewBlockManager(rp)
-				go bm.Handle()
+				go bm.Manage()
 			})
 
 			It("should return error about the missing transaction in the pool", func(done Done) {
@@ -135,7 +135,7 @@ var _ = Describe("Block", func() {
 				Expect(err).To(BeNil())
 
 				bm := node.NewBlockManager(rp)
-				go bm.Handle()
+				go bm.Manage()
 			})
 
 			Specify("relayed block must be processed by the remote peer", func(done Done) {
@@ -171,7 +171,7 @@ var _ = Describe("Block", func() {
 
 			BeforeEach(func() {
 				bm := node.NewBlockManager(rp)
-				go bm.Handle()
+				go bm.Manage()
 
 				block2 = MakeBlockWithSingleTx(lp.GetBlockchain(), lp.GetBlockchain().GetBestChain(), sender, sender, 1)
 				_, err := lp.GetBlockchain().ProcessBlock(block2)
@@ -219,7 +219,7 @@ var _ = Describe("Block", func() {
 
 		BeforeEach(func() {
 			bm := node.NewBlockManager(rp)
-			go bm.Handle()
+			go bm.Manage()
 
 			block2 = MakeBlockWithSingleTx(lp.GetBlockchain(), lp.GetBlockchain().GetBestChain(), sender, sender, 1)
 			_, err := lp.GetBlockchain().ProcessBlock(block2)

--- a/node/gossip/getaddr.go
+++ b/node/gossip/getaddr.go
@@ -9,7 +9,7 @@ import (
 // SendGetAddrToPeer sends a core.GetAddr message to a remote peer.
 // The remote peer will respond with a core.Addr message which
 // must be processed using the OnAddr handler and return the response.
-func (g *GossipManager) SendGetAddrToPeer(rp core.Engine) ([]*core.Address, error) {
+func (g *Manager) SendGetAddrToPeer(rp core.Engine) ([]*core.Address, error) {
 
 	s, c, err := g.NewStream(rp, config.Versions.GetAddr)
 	if err != nil {
@@ -39,7 +39,7 @@ func (g *GossipManager) SendGetAddrToPeer(rp core.Engine) ([]*core.Address, erro
 // SendGetAddr sends simultaneous GetAddr message
 // to the given peers. GetAddr returns with a list
 // of address that should be relayed to other peers.
-func (g *GossipManager) SendGetAddr(remotePeers []core.Engine) error {
+func (g *Manager) SendGetAddr(remotePeers []core.Engine) error {
 
 	// we need to know if we need more peers before we requests
 	// more addresses from other peers.
@@ -69,7 +69,7 @@ func (g *GossipManager) SendGetAddr(remotePeers []core.Engine) error {
 
 // OnGetAddr processes a core.GetAddr request.
 // Sends a list of active addresses to the sender
-func (g *GossipManager) OnGetAddr(s net.Stream, rp core.Engine) error {
+func (g *Manager) OnGetAddr(s net.Stream, rp core.Engine) error {
 
 	defer s.Close()
 

--- a/node/gossip/gossip.go
+++ b/node/gossip/gossip.go
@@ -26,9 +26,6 @@ const (
 	// EventRequestedBlockHashes describes an event about
 	// sending a request for block hashes
 	EventRequestedBlockHashes = "event.requestedBlockHashes"
-	// EventTransactionProcessed describes an event about
-	// a processed transaction
-	EventTransactionProcessed = "event.transactionProcessed"
 	//EventAddrProcessed describes an event about
 	// a processed address
 	EventAddrProcessed = "event.addrProcessed"
@@ -43,8 +40,8 @@ const (
 	EventIntroReceived = "event.receivedIntro"
 )
 
-// GossipManager represents the peer protocol
-type GossipManager struct {
+// Manager represents the peer protocol
+type Manager struct {
 
 	// mtx is the general mutex
 	mtx sync.RWMutex
@@ -68,8 +65,8 @@ type GossipManager struct {
 }
 
 // NewGossip creates a new instance of the Gossip protocol
-func NewGossip(p core.Engine, log logger.Logger) *GossipManager {
-	return &GossipManager{
+func NewGossip(p core.Engine, log logger.Logger) *Manager {
+	return &Manager{
 		engine:       p,
 		log:          log,
 		mtx:          sync.RWMutex{},
@@ -78,23 +75,23 @@ func NewGossip(p core.Engine, log logger.Logger) *GossipManager {
 }
 
 // SetPeerManager sets the peer manager
-func (g *GossipManager) SetPeerManager(pm *peermanager.Manager) {
+func (g *Manager) SetPeerManager(pm *peermanager.Manager) {
 	g.pm = pm
 }
 
 // PM returns the local peer's peer manager
-func (g *GossipManager) PM() *peermanager.Manager {
+func (g *Manager) PM() *peermanager.Manager {
 	return g.pm
 }
 
 // GetBlockchain returns the blockchain manager
-func (g *GossipManager) GetBlockchain() types.Blockchain {
+func (g *Manager) GetBlockchain() types.Blockchain {
 	return g.engine.GetBlockchain()
 }
 
 // NewStream creates a stream for a given protocol
 // ID and between the local peer and the given remote peer.
-func (g *GossipManager) NewStream(remotePeer core.Engine, msgVersion string) (net.Stream,
+func (g *Manager) NewStream(remotePeer core.Engine, msgVersion string) (net.Stream,
 	context.CancelFunc, error) {
 	ctxDur := time.Second * time.Duration(g.engine.GetCfg().Node.MessageTimeout)
 	ctx, cf := context.WithTimeout(context.TODO(), ctxDur)
@@ -107,7 +104,7 @@ func (g *GossipManager) NewStream(remotePeer core.Engine, msgVersion string) (ne
 }
 
 // CheckRemotePeer performs validation against the remote peer.
-func (g *GossipManager) CheckRemotePeer(ws *core.WrappedStream, rp core.Engine) error {
+func (g *Manager) CheckRemotePeer(ws *core.WrappedStream, rp core.Engine) error {
 
 	s := ws.Stream
 	skipAcquaintanceCheck := false
@@ -138,7 +135,7 @@ func (g *GossipManager) CheckRemotePeer(ws *core.WrappedStream, rp core.Engine) 
 
 // Handle wrappers a protocol handler providing an
 // interface to perform pre and post handling operations.
-func (g *GossipManager) Handle(handler func(s net.Stream, remotePeer core.Engine) error) func(net.Stream) {
+func (g *Manager) Handle(handler func(s net.Stream, remotePeer core.Engine) error) func(net.Stream) {
 	return func(s net.Stream) {
 
 		remoteAddr := util.RemoteAddrFromStream(s)
@@ -175,7 +172,7 @@ func WriteStream(s net.Stream, msg interface{}) error {
 	return nil
 }
 
-func (g *GossipManager) logErr(err error, rp core.Engine, msg string) error {
+func (g *Manager) logErr(err error, rp core.Engine, msg string) error {
 	g.log.Debug(msg, "Err", err, "PeerID", rp.ShortID())
 	return err
 }
@@ -183,7 +180,7 @@ func (g *GossipManager) logErr(err error, rp core.Engine, msg string) error {
 // logConnectErr updates the failure count record of a node
 // that failed to connect. It will also add a 1 hour ban time
 // if the node failed to connect after n tries.
-func (g *GossipManager) logConnectErr(err error, rp core.Engine, msg string) error {
+func (g *Manager) logConnectErr(err error, rp core.Engine, msg string) error {
 
 	// Increase connection fail count
 	g.PM().IncrConnFailCount(rp.GetAddress())
@@ -200,6 +197,6 @@ func (g *GossipManager) logConnectErr(err error, rp core.Engine, msg string) err
 }
 
 // GetBroadcasters returns the broadcasters
-func (g *GossipManager) GetBroadcasters() *core.BroadcastPeers {
+func (g *Manager) GetBroadcasters() *core.BroadcastPeers {
 	return g.broadcasters
 }

--- a/node/gossip/gossip_suite_test.go
+++ b/node/gossip/gossip_suite_test.go
@@ -61,7 +61,6 @@ func makeTestNodeWith(port int, seed int) *node.Node {
 
 	evtEmitter := &emitter.Emitter{}
 	txp := txpool.New(100)
-	txp.SetEventEmitter(evtEmitter)
 
 	bc := blockchain.New(txp, cfg, log)
 	bc.SetEventEmitter(evtEmitter)
@@ -83,6 +82,10 @@ func makeTestNodeWith(port int, seed int) *node.Node {
 
 	n.SetTxsPool(txp)
 	n.SetBlockchain(bc)
+
+	tm := node.NewTxManager(n)
+	n.SetTxManager(tm)
+	go tm.Manage()
 
 	return n
 }

--- a/node/gossip/handshake.go
+++ b/node/gossip/handshake.go
@@ -35,7 +35,7 @@ func createHandshakeMsg(msg *core.Handshake, bestChain types.ChainReader,
 }
 
 // SendHandshake sends an introductory message to a peer
-func (g *GossipManager) SendHandshake(rp core.Engine) error {
+func (g *Manager) SendHandshake(rp core.Engine) error {
 
 	rpIDShort := rp.ShortID()
 
@@ -94,7 +94,7 @@ func (g *GossipManager) SendHandshake(rp core.Engine) error {
 }
 
 // OnHandshake handles incoming handshake requests
-func (g *GossipManager) OnHandshake(s net.Stream, rp core.Engine) error {
+func (g *Manager) OnHandshake(s net.Stream, rp core.Engine) error {
 
 	msg := &core.Handshake{}
 	if err := ReadStream(s, msg); err != nil {

--- a/node/gossip/intro.go
+++ b/node/gossip/intro.go
@@ -11,7 +11,7 @@ import (
 // random, connected peers. If intro is nil,
 // a new core.Intro message is created and
 // broadcast to the selected peers
-func (g *GossipManager) SendIntro(intro *core.Intro) {
+func (g *Manager) SendIntro(intro *core.Intro) {
 
 	// Get the addresses of the nodes
 	// this peer is connected to.
@@ -75,7 +75,7 @@ func (g *GossipManager) SendIntro(intro *core.Intro) {
 
 // OnIntro handles incoming core.Intro messages.
 // Received messages are relayed to 2 random peers.
-func (g *GossipManager) OnIntro(s net.Stream, rp core.Engine) error {
+func (g *Manager) OnIntro(s net.Stream, rp core.Engine) error {
 
 	defer s.Reset()
 

--- a/node/gossip/ping.go
+++ b/node/gossip/ping.go
@@ -14,7 +14,7 @@ import (
 // It receives the response Pong message and will start
 // blockchain synchronization if the Pong message includes
 // blockchain information that is better than the local blockchain
-func (g *GossipManager) SendPingToPeer(remotePeer core.Engine) error {
+func (g *Manager) SendPingToPeer(remotePeer core.Engine) error {
 
 	rpIDShort := remotePeer.ShortID()
 	s, c, err := g.NewStream(remotePeer, config.Versions.Ping)
@@ -69,7 +69,7 @@ func (g *GossipManager) SendPingToPeer(remotePeer core.Engine) error {
 }
 
 // SendPing sends a ping message
-func (g *GossipManager) SendPing(remotePeers []core.Engine) {
+func (g *Manager) SendPing(remotePeers []core.Engine) {
 	sent := 0
 	for _, peer := range remotePeers {
 		if !g.PM().IsAcquainted(peer) {
@@ -92,7 +92,7 @@ func (g *GossipManager) SendPing(remotePeers []core.Engine) {
 // blockchain synchronization if the Ping message includes
 // blockchain information that is better than the local
 // blockchain
-func (g *GossipManager) OnPing(s net.Stream, rp core.Engine) error {
+func (g *Manager) OnPing(s net.Stream, rp core.Engine) error {
 
 	defer s.Close()
 

--- a/node/gossip/self_adv.go
+++ b/node/gossip/self_adv.go
@@ -9,7 +9,7 @@ import (
 
 // SelfAdvertise sends an Addr message containing
 // the address of the local peer to all connected peers.
-func (g *GossipManager) SelfAdvertise(connectedPeers []core.Engine) int {
+func (g *Manager) SelfAdvertise(connectedPeers []core.Engine) int {
 
 	msg := &core.Addr{
 		Addresses: []*core.Address{

--- a/node/gossip/transaction.go
+++ b/node/gossip/transaction.go
@@ -24,7 +24,7 @@ func (g *Manager) OnTx(s net.Stream, rp core.Engine) error {
 	msg := &core.TxInfo{}
 	if err := ReadStream(s, msg); err != nil {
 		s.Reset()
-		return g.logErr(err, rp, "[OnTx] Failed to read")
+		return g.logErr(err, rp, "[OnTx] Failed to read TxInfo message")
 	}
 
 	// We can't accept a transaction that already
@@ -84,7 +84,7 @@ func (g *Manager) BroadcastTx(tx types.Transaction, remotePeers []core.Engine) e
 		}
 		defer c()
 
-		// Send a transaction info describing the transaction.
+		// Send a message describing the transaction.
 		// If the peer accepts the transaction, we can send the full tx.
 		txInfo := core.TxInfo{Hash: tx.GetHash()}
 		if err := WriteStream(s, txInfo); err != nil {
@@ -103,7 +103,7 @@ func (g *Manager) BroadcastTx(tx types.Transaction, remotePeers []core.Engine) e
 
 		if !txOk.Ok {
 			s.Reset()
-			g.log.Debug("Peer has rejected a transaction",
+			g.log.Debug("Peer rejected our intent to broadcast a transaction",
 				"PeerID", peer.ShortID(), "TxID", txID)
 			continue
 		}
@@ -115,7 +115,7 @@ func (g *Manager) BroadcastTx(tx types.Transaction, remotePeers []core.Engine) e
 			continue
 		}
 
-		g.log.Info("Transaction successfully broadcast to peer",
+		g.log.Info("Transaction successfully broadcast",
 			"TxID", txID, "NumPeersSentTo", sent)
 
 		s.Close()
@@ -123,28 +123,3 @@ func (g *Manager) BroadcastTx(tx types.Transaction, remotePeers []core.Engine) e
 
 	return nil
 }
-
-// 	historyKey := MakeTxHistoryKey(tx, peer)
-
-// 	if g.engine.GetHistory().HasMulti(historyKey...) {
-// 		continue
-// 	}
-
-// 	s, c, err := g.NewStream(peer, config.Versions.Tx)
-// 	if err != nil {
-// 		g.logConnectErr(err, peer, "[BroadcastTx] Failed to connect")
-// 		continue
-// 	}
-// 	defer c()
-// 	defer s.Close()
-
-// 	if err := WriteStream(s, tx); err != nil {
-// 		s.Reset()
-// 		g.log.Debug("Tx message failed. failed to write to stream",
-// 			"Err", err, "PeerID", peer.ShortID())
-// 		continue
-// 	}
-
-// 	g.engine.GetHistory().AddMulti(cache.Sec(600), historyKey...)
-
-// 	sent++

--- a/node/node_suite_test.go
+++ b/node/node_suite_test.go
@@ -61,7 +61,6 @@ func makeTestNodeWith(port int, seed int) *Node {
 
 	evtEmitter := &emitter.Emitter{}
 	txp := txpool.New(100)
-	txp.SetEventEmitter(evtEmitter)
 
 	bc := blockchain.New(txp, cfg, log)
 	bc.SetEventEmitter(evtEmitter)

--- a/node/peermanager/peer_mgr.go
+++ b/node/peermanager/peer_mgr.go
@@ -654,9 +654,16 @@ func (m *Manager) LoadPeers() error {
 
 		addr := util.NodeAddr(addrData["address"].(string))
 		peer := m.localNode.NewRemoteNode(addr)
+
+		// Do not overwrite peer if it already exists
+		// in the peer list. The peer might have been
+		// added by a different process during bootstrap.
+		if m.PeerExist(peer.StringID()) {
+			continue
+		}
+
 		peer.SetCreatedAt(time.Unix(int64(addrData["createdAt"].(uint32)), 0))
 		peer.SetLastSeen(time.Unix(int64(addrData["lastSeen"].(uint32)), 0))
-
 		m.AddPeer(peer)
 
 		if addrData["banTime"] != nil {

--- a/node/peermanager/peermanager_suite_test.go
+++ b/node/peermanager/peermanager_suite_test.go
@@ -65,7 +65,6 @@ func makeTestNodeWith(port int, seed int) *node.Node {
 
 	evtEmitter := &emitter.Emitter{}
 	txp := txpool.New(100)
-	txp.SetEventEmitter(evtEmitter)
 
 	bc := blockchain.New(txp, cfg, log)
 	bc.SetEventEmitter(evtEmitter)

--- a/node/transaction_manager.go
+++ b/node/transaction_manager.go
@@ -1,0 +1,113 @@
+package node
+
+import (
+	"fmt"
+	"time"
+
+	"gopkg.in/oleiade/lane.v1"
+
+	"github.com/ellcrys/elld/blockchain"
+	"github.com/ellcrys/elld/types"
+	"github.com/ellcrys/elld/types/core"
+	"github.com/ellcrys/elld/util/logger"
+	"github.com/olebedev/emitter"
+)
+
+// TxManager is responsible for processing
+// incoming transactions, constructing new
+// transactions and more.
+type TxManager struct {
+
+	// engine is the node's instance
+	engine *Node
+
+	// evt is the global event emitter
+	evt *emitter.Emitter
+
+	// log is the logger used by this module
+	log logger.Logger
+
+	// bChain is the blockchain manager
+	bChain types.Blockchain
+
+	// txBroadcastQueue store transactions to broadcast
+	txBroadcastQueue *lane.Deque
+}
+
+// NewTxManager creates a new transaction manager
+func NewTxManager(n *Node) *TxManager {
+	return &TxManager{
+		engine:           n,
+		log:              n.log,
+		evt:              n.event,
+		bChain:           n.bChain,
+		txBroadcastQueue: lane.NewDeque(),
+	}
+}
+
+// Manage incoming transaction related events
+func (tm *TxManager) Manage() {
+
+	go func() {
+		ticker := time.NewTicker(3 * time.Second)
+		for {
+			select {
+			case <-ticker.C:
+				go tm.broadcastTx()
+			}
+		}
+	}()
+
+	go func() {
+		for evt := range tm.evt.Once(core.EventTransactionReceived) {
+			tm.AddTx(evt.Args[0].(*core.Transaction))
+		}
+	}()
+}
+
+// AddTx adds a transaction to the pool
+func (tm *TxManager) AddTx(tx types.Transaction) error {
+
+	// TxTypeAlloc transactions are not allowed
+	if tx.GetType() == core.TxTypeAlloc {
+		err := fmt.Errorf("allocation transaction type is not allowed")
+		tm.evt.Emit(core.EventTransactionInvalid, tx, err)
+		return err
+	}
+
+	// We need to validate the transaction, returning
+	// the first error we find.
+	txValidator := blockchain.NewTxValidator(tx, tm.engine.txsPool, tm.bChain)
+	if errs := txValidator.Validate(); len(errs) > 0 {
+		tm.evt.Emit(core.EventTransactionInvalid, tx, errs[0])
+		return errs[0]
+	}
+
+	// Next we attempt to add the transaction
+	// to the transactions pool.
+	if err := tm.engine.GetTxPool().Put(tx); err != nil {
+		tm.evt.Emit(core.EventTransactionInvalid, tx, err)
+		return err
+	}
+
+	// Since we successfully added the transaction
+	// to the pool, we need to add it to the
+	// broadcast queue so it will be broadcast to peers
+	tm.txBroadcastQueue.Append(tx)
+
+	tm.evt.Emit(core.EventTransactionPooled, tx)
+
+	return nil
+}
+
+// broadcastTx broadcast a transaction
+func (tm *TxManager) broadcastTx() error {
+
+	tx := tm.txBroadcastQueue.Shift()
+	if tx == nil {
+		return nil
+	}
+
+	return tm.engine.gossipMgr.BroadcastTx(tx.(types.Transaction),
+		tm.engine.PM().GetActivePeers(0))
+}

--- a/params/protocol_params.go
+++ b/params/protocol_params.go
@@ -5,7 +5,34 @@ import (
 	"time"
 )
 
+// Gossip parameters
 var (
+	// MaxGetBlockHashes is the max number of block headers to request
+	// from a remote peer per request.
+	MaxGetBlockHashes = int64(5)
+)
+
+// Monetary parameters
+var (
+	// Decimals is the number of coin decimal places
+	Decimals = int32(18)
+)
+
+// Block parameters
+var (
+	// AllowedFutureBlockTime is the number of seconds
+	// a block's timestamp can have beyond the current timestamp
+	AllowedFutureBlockTime = 15 * time.Second
+
+	// MaxBlockNonTxsSize is the maximum size
+	// of the non-transactional data a block
+	// can have (headers, signature, hash).
+	MaxBlockNonTxsSize = int64(1024)
+
+	// MaxBlockTxsSize is the maximum size of
+	// transactions that can fit in a block
+	MaxBlockTxsSize = int64(9998976)
+
 	// MaximumExtraDataSize is the size of extra data a block can contain.
 	MaximumExtraDataSize uint64 = 32
 
@@ -31,31 +58,8 @@ var (
 	MinimumDurationIncrease = big.NewFloat(2)
 )
 
+// Transaction parameters
 var (
-	// MaxGetBlockHashes is the max number of block headers to request
-	// from a remote peer per request.
-	MaxGetBlockHashes = int64(5)
-)
-
-var (
-	// Decimals is the number of coin decimal places
-	Decimals = int32(18)
-)
-
-var (
-	// AllowedFutureBlockTime is the number of seconds
-	// a block's timestamp can have beyond the current timestamp
-	AllowedFutureBlockTime = 15 * time.Second
-
-	// MaxBlockNonTxsSize is the maximum size
-	// of the non-transactional data a block
-	// can have (headers, signature, hash).
-	MaxBlockNonTxsSize = int64(1024)
-
-	// MaxBlockTxsSize is the maximum size of
-	// transactions that can fit in a block
-	MaxBlockTxsSize = int64(9998976)
-
 	// PoolCapacity is the max. number of transaction
 	// that can be added to the transaction pool at
 	// any given time.

--- a/types/core/engine.go
+++ b/types/core/engine.go
@@ -131,10 +131,6 @@ type Engine interface {
 	// GetIntros returns the cache containing received intros
 	GetIntros() *cache.Cache
 
-	// AddTransaction validates and adds a
-	// transaction to the transaction pool.
-	AddTransaction(tx types.Transaction) error
-
 	// SetHardcodedState sets the hardcoded seed state
 	// of the engine.
 	SetHardcodedState(v bool)
@@ -159,12 +155,4 @@ type SyncStateInfo struct {
 	CurrentTD          *big.Int `json:"currentTotalDifficulty" msgpack:"currentTotalDifficulty"`
 	CurrentChainHeight uint64   `json:"currentChainHeight" msgpack:"currentChainHeight"`
 	ProgressPercent    float64  `json:"progressPercent" msgpack:"progressPercent"`
-}
-
-// BlockManager is responsible for handling
-// incoming, mined or processed blocks in a
-// concurrency safe way.
-type BlockManager interface {
-	IsSyncing() bool
-	GetSyncStateInfo() *SyncStateInfo
 }

--- a/types/core/events.go
+++ b/types/core/events.go
@@ -13,6 +13,18 @@ const (
 	// transaction that was received
 	EventNewTransaction = "event.newTx"
 
+	// EventTransactionReceived indicates that a transaction
+	// has been received.
+	EventTransactionReceived = "event.txReceived"
+
+	// EventTransactionPooled indicates that a transaction
+	// has been added to the transaction pool
+	EventTransactionPooled = "event.txPooled"
+
+	// EventTransactionInvalid indicates that a transaction
+	// has been declared invalid
+	EventTransactionInvalid = "event.txInvalid"
+
 	// EventOrphanBlock represents an event about an orphan block.
 	EventOrphanBlock = "event.orphanBlock"
 

--- a/types/core/gossip.go
+++ b/types/core/gossip.go
@@ -154,6 +154,17 @@ type Intro struct {
 	PeerID string `json:"id" msgpack:"id"`
 }
 
+// TxInfo describes a transaction
+type TxInfo struct {
+	Hash util.Hash `json:"hash" msgpack:"hash"`
+}
+
+// TxOk describes a transaction hash received
+// in TxInfo as accepted/ok or not
+type TxOk struct {
+	Ok bool `json:"ok" msgpack:"ok"`
+}
+
 // Hash returns the hash representation
 func (m *Intro) Hash() util.Hash {
 	bs := util.ObjectToBytes([]interface{}{m.PeerID})
@@ -206,7 +217,7 @@ type Gossip interface {
 	OnIntro(s net.Stream, rp Engine) error
 
 	// Transaction messages
-	RelayTx(tx types.Transaction, remotePeers []Engine) error
+	BroadcastTx(tx types.Transaction, remotePeers []Engine) error
 	OnTx(s net.Stream, rp Engine) error
 
 	// PickBroadcasters selects N random addresses from

--- a/types/core/gossip.go
+++ b/types/core/gossip.go
@@ -165,6 +165,17 @@ type TxOk struct {
 	Ok bool `json:"ok" msgpack:"ok"`
 }
 
+// BlockInfo describes a block
+type BlockInfo struct {
+	Hash util.Hash `json:"hash" msgpack:"hash"`
+}
+
+// BlockOk describes a block hash received
+// in BlockInfo as accepted/ok or not
+type BlockOk struct {
+	Ok bool `json:"ok" msgpack:"ok"`
+}
+
 // Hash returns the hash representation
 func (m *Intro) Hash() util.Hash {
 	bs := util.ObjectToBytes([]interface{}{m.PeerID})
@@ -186,7 +197,8 @@ type Gossip interface {
 	RelayAddresses(addrs []*Address) []error
 
 	// Block messages
-	RelayBlock(block types.Block, remotePeers []Engine) error
+	BroadcastBlock(block types.Block, remotePeers []Engine) error
+	OnBlockInfo(s net.Stream, rp Engine) error
 	OnBlockBody(s net.Stream, rp Engine) error
 	RequestBlock(rp Engine, blockHash util.Hash) error
 	OnRequestBlock(s net.Stream, rp Engine) error

--- a/types/interfaces.go
+++ b/types/interfaces.go
@@ -369,9 +369,7 @@ type TxContainer interface {
 
 // TxPool represents a transactions pool
 type TxPool interface {
-	SetEventEmitter(ee *emitter.Emitter)
 	Put(tx Transaction) error
-	PutSilently(tx Transaction) error
 	Has(tx Transaction) bool
 	HasByHash(hash string) bool
 	Remove(txs ...Transaction)


### PR DESCRIPTION
# Commit Summary

### Node
* Immediately unsubscribe block manager events handler after each execution.
* Improved transaction broadcast rules to be more polite & bandwidth-friendly.
* Improved block broadcast rules to be more polite & bandwidth-friendly.
* Transaction events are now handled by the new and dedicated transaction manager.
* Prevented existing peer information from being updated when loading peers from disk. 
* Renamed `GossipManager` to `Manager`.
* Removed engine behaviours that are now handled in the transaction manager.
* Transaction pool no longer emits any events.

### Others
* Removed unused `SetEventEmitter` and `PutSilently` methods from `TxPool` interface.
* Renamed `RelayTx ` to `BroadcastTx `.