### PR TITLE
Categorized Broadcast Peers & Sync Threshold

### DIFF
--- a/node/api.go
+++ b/node/api.go
@@ -273,6 +273,22 @@ func (n *Node) apiFetchPool(arg interface{}) *jsonrpc.Response {
 	return jsonrpc.Success(txs)
 }
 
+func (n *Node) apiBroadcastPeers(arg interface{}) *jsonrpc.Response {
+	var result = map[string][]string{
+		"broadcasters":       []string{},
+		"randomBroadcasters": []string{},
+	}
+	for _, p := range n.Gossip().GetBroadcasters().Peers() {
+		result["broadcasters"] = append(result["broadcasters"],
+			p.GetAddress().ConnectionString())
+	}
+	for _, p := range n.Gossip().GetRandBroadcasters().Peers() {
+		result["randomBroadcasters"] = append(result["randomBroadcasters"],
+			p.GetAddress().ConnectionString())
+	}
+	return jsonrpc.Success(result)
+}
+
 // APIs returns all API handlers
 func (n *Node) APIs() jsonrpc.APISet {
 	return map[string]jsonrpc.APIInfo{
@@ -361,6 +377,11 @@ func (n *Node) APIs() jsonrpc.APISet {
 			Private:     true,
 			Description: "Delete all peers in memory and on disk",
 			Func:        n.apiForgetPeers,
+		},
+		"broadcasters": {
+			Namespace:   types.NamespaceNet,
+			Description: "Get broadcast peers",
+			Func:        n.apiBroadcastPeers,
 		},
 
 		// namespace: "pool"

--- a/node/block_manager.go
+++ b/node/block_manager.go
@@ -194,7 +194,7 @@ func (bm *BlockManager) handleProcessedBlocks() error {
 	// Relay the block to peers.
 	if b.(*core.Block).GetNumber() > 1 {
 		bm.engine.Gossip().BroadcastBlock(b.(*core.Block),
-			bm.engine.PM().GetConnectedPeers())
+			bm.engine.PM().GetAcquaintedPeers())
 	}
 
 	return nil

--- a/node/gossip/addr.go
+++ b/node/gossip/addr.go
@@ -156,9 +156,10 @@ func (g *Manager) RelayAddresses(addrs []*core.Address) []error {
 	}
 
 	// Select up to 2 peers to act as broadcasters
-	broadcasters := g.PickBroadcasters(relayable, 2)
+	broadcasters := g.PickBroadcasters(g.randBroadcasters, relayable, 3)
 
-	g.log.Debug("Relaying addresses", "NumAddrs", len(relayable),
+	g.log.Debug("Relaying addresses",
+		"NumAddrs", len(relayable),
 		"NumBroadcasters", broadcasters.Len())
 
 	relayed := 0

--- a/node/gossip/addr_test.go
+++ b/node/gossip/addr_test.go
@@ -39,6 +39,8 @@ var _ = Describe("TestAddr", func() {
 			Address: util.String(sender.Addr()),
 			Balance: "100",
 		})).To(BeNil())
+
+		Expect(lp.Connect(rp)).To(BeNil())
 	})
 
 	AfterEach(func() {
@@ -121,7 +123,7 @@ var _ = Describe("TestAddr", func() {
 
 	Describe(".OnAddr", func() {
 
-		var p, p2, p3 *node.Node
+		var p, p2, p3, p4 *node.Node
 		var evt emitter.Event
 		var addrMsg *core.Addr
 
@@ -129,11 +131,13 @@ var _ = Describe("TestAddr", func() {
 			p = makeTestNode(getPort())
 			p2 = makeTestNode(getPort())
 			p3 = makeTestNode(getPort())
+			p4 = makeTestNode(getPort())
 			addrMsg = &core.Addr{
 				Addresses: []*core.Address{
 					{Address: p.GetAddress(), Timestamp: time.Now().Unix()},
 					{Address: p2.GetAddress(), Timestamp: time.Now().Unix()},
 					{Address: p3.GetAddress(), Timestamp: time.Now().Unix()},
+					{Address: p4.GetAddress(), Timestamp: time.Now().Unix()},
 				},
 			}
 		})
@@ -142,6 +146,7 @@ var _ = Describe("TestAddr", func() {
 			closeNode(p)
 			closeNode(p2)
 			closeNode(p3)
+			closeNode(p4)
 		})
 
 		Describe("when the number of addresses is below max address expected", func() {
@@ -161,7 +166,7 @@ var _ = Describe("TestAddr", func() {
 					defer GinkgoRecover()
 					evt = <-rp.GetEventEmitter().On(gossip.EventAddressesRelayed)
 					Expect(evt.Args).To(BeEmpty())
-					Expect(rp.Gossip().GetRandBroadcasters().Len()).To(Equal(2))
+					Expect(rp.Gossip().GetRandBroadcasters().Len()).To(Equal(3))
 					close(wait)
 				}()
 

--- a/node/gossip/addr_test.go
+++ b/node/gossip/addr_test.go
@@ -46,8 +46,6 @@ var _ = Describe("TestAddr", func() {
 		closeNode(rp)
 	})
 
-
-
 	Describe(".RelayAddresses", func() {
 
 		It("should return err='too many items in addr message' when address is more than 10", func() {
@@ -114,9 +112,9 @@ var _ = Describe("TestAddr", func() {
 					{Address: p2.GetAddress(), Timestamp: time.Now().Unix()},
 					{Address: p3.GetAddress(), Timestamp: time.Now().Unix()},
 				}
-				Expect(p.Gossip().GetBroadcasters().Len()).To(Equal(0))
+				Expect(p.Gossip().GetRandBroadcasters().Len()).To(Equal(0))
 				p.Gossip().RelayAddresses(addrs)
-				Expect(p.Gossip().GetBroadcasters().Len()).To(Equal(2))
+				Expect(p.Gossip().GetRandBroadcasters().Len()).To(Equal(2))
 			})
 		})
 	})
@@ -163,7 +161,7 @@ var _ = Describe("TestAddr", func() {
 					defer GinkgoRecover()
 					evt = <-rp.GetEventEmitter().On(gossip.EventAddressesRelayed)
 					Expect(evt.Args).To(BeEmpty())
-					Expect(rp.Gossip().GetBroadcasters().Len()).To(Equal(2))
+					Expect(rp.Gossip().GetRandBroadcasters().Len()).To(Equal(2))
 					close(wait)
 				}()
 

--- a/node/gossip/block.go
+++ b/node/gossip/block.go
@@ -20,7 +20,7 @@ import (
 func (g *Manager) BroadcastBlock(block types.Block, remotePeers []core.Engine) error {
 
 	var sent int
-	broadcastPeers := g.PickBroadcastersFromPeers(remotePeers, 2)
+	broadcastPeers := g.PickBroadcastersFromPeers(g.broadcasters, remotePeers, 3)
 	for _, peer := range broadcastPeers.Peers() {
 
 		// We need to remove the broadcast peer

--- a/node/gossip/gossip_test.go
+++ b/node/gossip/gossip_test.go
@@ -94,18 +94,24 @@ var _ = Describe("Gossip", func() {
 
 	Describe(".PickBroadcasters", func() {
 
-		var candidateAddrs = []*core.Address{
-			{Address: "/ip4/172.16.238.10/tcp/9000/ipfs/12D3KooWHHzSeKaY8xuZVzkLbKFfvNgPPeKhFBGrMbNzbm5akpqu"},
-			{Address: "/ip4/172.16.238.11/tcp/9000/ipfs/12D3KooWB1b3qZxWJanuhtseF3DmPggHCtG36KZ9ixkqHtdKH9fh"},
-			{Address: "/ip4/172.16.238.12/tcp/9000/ipfs/12D3KooWPgam4TzSVCRa4AbhxQnM9abCYR4E9hV57SN7eAjEYn1j"},
-			{Address: "/ip4/172.16.238.13/tcp/9000/ipfs/12D3KooWKRyzVWW6ChFjQjK4miCty85Niy49tpPV95XdKu1BcvMA"},
-			{Address: "/ip4/172.16.238.14/tcp/9000/ipfs/12D3KooWE4qDcRrueTuRYWUdQZgcy7APZqBngVeXRt4Y6ytHizKV"},
-		}
+		var candidateAddrs []*core.Address
+		var cache *core.BroadcastPeers
+
+		BeforeEach(func() {
+			cache = core.NewBroadcastPeers()
+			candidateAddrs = []*core.Address{
+				{Address: "/ip4/172.16.238.10/tcp/9000/ipfs/12D3KooWHHzSeKaY8xuZVzkLbKFfvNgPPeKhFBGrMbNzbm5akpqu"},
+				{Address: "/ip4/172.16.238.11/tcp/9000/ipfs/12D3KooWB1b3qZxWJanuhtseF3DmPggHCtG36KZ9ixkqHtdKH9fh"},
+				{Address: "/ip4/172.16.238.12/tcp/9000/ipfs/12D3KooWPgam4TzSVCRa4AbhxQnM9abCYR4E9hV57SN7eAjEYn1j"},
+				{Address: "/ip4/172.16.238.13/tcp/9000/ipfs/12D3KooWKRyzVWW6ChFjQjK4miCty85Niy49tpPV95XdKu1BcvMA"},
+				{Address: "/ip4/172.16.238.14/tcp/9000/ipfs/12D3KooWE4qDcRrueTuRYWUdQZgcy7APZqBngVeXRt4Y6ytHizKV"},
+			}
+		})
 
 		Describe("cache contains no address", func() {
 			Describe("many candidate addresses is passed", func() {
 				It("should return N nodes", func() {
-					broadcasters := lp.Gossip().PickBroadcasters(candidateAddrs, 2)
+					broadcasters := lp.Gossip().PickBroadcasters(cache, candidateAddrs, 2)
 					Expect(broadcasters.Len()).To(Equal(2))
 					Expect(broadcasters.PeersID()).To(ContainElement(candidateAddrs[2].Address.StringID()))
 					Expect(broadcasters.PeersID()).To(ContainElement(candidateAddrs[1].Address.StringID()))
@@ -118,7 +124,7 @@ var _ = Describe("Gossip", func() {
 				}
 
 				It("Should return the only candidate node", func() {
-					broadcasters := lp.Gossip().PickBroadcasters(candidateAddrs, 2)
+					broadcasters := lp.Gossip().PickBroadcasters(cache, candidateAddrs, 2)
 					Expect(broadcasters.Len()).To(Equal(1))
 					Expect(broadcasters.PeersID()).To(ContainElement(candidateAddrs[0].Address.StringID()))
 				})
@@ -137,7 +143,7 @@ var _ = Describe("Gossip", func() {
 			})
 
 			It("should clear the cache and select new addresses", func() {
-				broadcasters = lp.Gossip().PickBroadcasters(candidateAddrs, 2)
+				broadcasters = lp.Gossip().PickBroadcasters(cache, candidateAddrs, 2)
 				Expect(broadcasters.Len()).To(Equal(2))
 				Expect(broadcasters.PeersID()).ToNot(ContainElement(addr.StringID()))
 			})
@@ -151,11 +157,11 @@ var _ = Describe("Gossip", func() {
 
 			BeforeEach(func() {
 				n := rp.NewRemoteNode(addr)
-				lp.Gossip().GetBroadcasters().Add(n)
+				cache.Add(n)
 			})
 
 			It("should leave the cache untouched and add the only candidate address", func() {
-				broadcasters := lp.Gossip().PickBroadcasters(candidateAddrs, 2)
+				broadcasters := lp.Gossip().PickBroadcasters(cache, candidateAddrs, 2)
 				Expect(broadcasters.Len()).To(Equal(2))
 				Expect(broadcasters.PeersID()).To(ContainElement(addr.StringID()))
 				Expect(broadcasters.PeersID()).To(ContainElement(candidateAddrs[0].Address.StringID()))
@@ -173,12 +179,12 @@ var _ = Describe("Gossip", func() {
 			}
 
 			BeforeEach(func() {
-				broadcasters = lp.Gossip().PickBroadcasters(candidateAddrs, 2)
+				broadcasters = lp.Gossip().PickBroadcasters(cache, candidateAddrs, 2)
 				Expect(broadcasters.Len()).To(Equal(2))
 			})
 
 			It("should return current cache values", func() {
-				broadcasters2 := lp.Gossip().PickBroadcasters(candidateAddrs2, 2)
+				broadcasters2 := lp.Gossip().PickBroadcasters(cache, candidateAddrs2, 2)
 				Expect(broadcasters2).To(Equal(broadcasters))
 			})
 		})

--- a/node/gossip/intro.go
+++ b/node/gossip/intro.go
@@ -13,18 +13,8 @@ import (
 // broadcast to the selected peers
 func (g *Manager) SendIntro(intro *core.Intro) {
 
-	// Get the addresses of the nodes
-	// this peer is connected to.
-	var connectedAddresses = []*core.Address{}
-	for _, p := range g.PM().GetConnectedPeers() {
-		connectedAddresses = append(connectedAddresses, &core.Address{
-			Address:   p.GetAddress(),
-			Timestamp: p.GetLastSeen().Unix(),
-		})
-	}
-
 	// Select up to 2 peers to act as broadcasters
-	g.PickBroadcasters(connectedAddresses, 2)
+	bp := g.PickBroadcastersFromPeers(g.randBroadcasters, g.PM().GetConnectedPeers(), 3)
 
 	var msg = intro
 	if msg == nil {
@@ -34,7 +24,7 @@ func (g *Manager) SendIntro(intro *core.Intro) {
 	// Send intro message to the selected
 	// broadcast nodes.
 	sent := 0
-	for _, peer := range g.broadcasters.Peers() {
+	for _, peer := range bp.Peers() {
 
 		// Don't relay an intro back to the
 		// peer that authored it

--- a/node/gossip/intro_test.go
+++ b/node/gossip/intro_test.go
@@ -41,6 +41,8 @@ var _ = Describe("Intro", func() {
 			Address: util.String(sender.Addr()),
 			Balance: "100",
 		})).To(BeNil())
+
+		Expect(lp.Connect(rp)).To(BeNil())
 	})
 
 	AfterEach(func() {

--- a/node/gossip/self_adv.go
+++ b/node/gossip/self_adv.go
@@ -17,20 +17,11 @@ func (g *Manager) SelfAdvertise(connectedPeers []core.Engine) int {
 		},
 	}
 
-	// Get the address of connected peers into a core.Address
-	var peersAddress = []*core.Address{}
-	for _, p := range connectedPeers {
-		peersAddress = append(peersAddress, &core.Address{
-			Address:   p.GetAddress(),
-			Timestamp: p.GetLastSeen().Unix(),
-		})
-	}
-
 	// Select up to 2 peers to act as broadcasters
-	g.PickBroadcasters(peersAddress, 2)
+	bp := g.PickBroadcastersFromPeers(g.randBroadcasters, connectedPeers, 3)
 
 	sent := 0
-	for _, peer := range g.broadcasters.Peers() {
+	for _, peer := range bp.Peers() {
 
 		s, c, err := g.NewStream(peer, config.Versions.Addr)
 		if err != nil {

--- a/node/gossip/self_adv_test.go
+++ b/node/gossip/self_adv_test.go
@@ -23,6 +23,8 @@ var _ = Describe("SelfAdv", func() {
 
 		rp = makeTestNode(rpPort)
 		Expect(rp.GetBlockchain().Up()).To(BeNil())
+
+		Expect(lp.Connect(rp)).To(BeNil())
 	})
 
 	AfterEach(func() {

--- a/node/gossip/transaction.go
+++ b/node/gossip/transaction.go
@@ -76,7 +76,7 @@ func (g *Manager) BroadcastTx(tx types.Transaction, remotePeers []core.Engine) e
 		"TxID", txID,
 		"NumPeers", len(remotePeers))
 
-	broadcastPeers := g.PickBroadcastersFromPeers(remotePeers, 2)
+	broadcastPeers := g.PickBroadcastersFromPeers(g.broadcasters, remotePeers, 3)
 	for _, peer := range broadcastPeers.Peers() {
 
 		// We need to remove the broadcast peer
@@ -133,12 +133,14 @@ func (g *Manager) BroadcastTx(tx types.Transaction, remotePeers []core.Engine) e
 			continue
 		}
 
-		g.log.Info("Transaction successfully broadcast",
-			"TxID", txID,
-			"NumPeersSentTo", sent)
+		sent++
 
 		s.Close()
 	}
+
+	g.log.Info("Transaction successfully broadcast",
+		"TxID", txID,
+		"NumPeersSentTo", sent)
 
 	return nil
 }

--- a/node/peermanager/peer_mgr.go
+++ b/node/peermanager/peer_mgr.go
@@ -243,10 +243,20 @@ func (m *Manager) GetLonelyPeers() (peers []core.Engine) {
 	return
 }
 
-// GetConnectedPeers returns the connected peers
+// GetConnectedPeers returns connected peers
 func (m *Manager) GetConnectedPeers() (peers []core.Engine) {
 	for _, p := range m.GetPeers() {
 		if p.Connected() {
+			peers = append(peers, p)
+		}
+	}
+	return
+}
+
+// GetAcquaintedPeers returns connected and acquainted peers
+func (m *Manager) GetAcquaintedPeers() (peers []core.Engine) {
+	for _, p := range m.GetPeers() {
+		if p.Connected() && m.IsAcquainted(p) {
 			peers = append(peers, p)
 		}
 	}

--- a/node/transaction_manager.go
+++ b/node/transaction_manager.go
@@ -109,5 +109,5 @@ func (tm *TxManager) broadcastTx() error {
 	}
 
 	return tm.engine.gossipMgr.BroadcastTx(tx.(types.Transaction),
-		tm.engine.PM().GetActivePeers(0))
+		tm.engine.PM().GetAcquaintedPeers())
 }

--- a/params/protocol_params.go
+++ b/params/protocol_params.go
@@ -53,6 +53,11 @@ var (
 	// MinimumDurationIncrease is the minimum percent increase
 	// a block's time can be when compared to its parent's
 	MinimumDurationIncrease = big.NewFloat(2)
+
+	// SyncMinHeightDiff is the number of blocks
+	// a remote peer can have more than the local
+	// peer to trigger block sync with the peer
+	SyncMinHeightDiff = uint64(3)
 )
 
 // Transaction parameters


### PR DESCRIPTION
# Commit Summary

### Node
- Separated broadcast peers into two groups (acquainted & possible unacquainted.
- Broadcast blocks and transactions to only acquainted peers.
- Increased broadcaster cache size to 3.
- Added an RPC API that returns the client's broadcasters.
- Block sync will not consider a peer as a sync candidate until a specific height difference is reached.
