### PR TITLE
Block Rebroadcast and Validation Behaviours

### DIFF
--- a/blockchain/block_validator_test.go
+++ b/blockchain/block_validator_test.go
@@ -223,66 +223,60 @@ var _ = Describe("BlockValidator", func() {
 	})
 
 	Describe(".CheckTransactions", func() {
-
 		Context("types.ContextBlock is set", func() {
-			Context("when ContextBlockSync is not set", func() {
-				Context("when transaction does not exist in pool", func() {
-					var block types.Block
-					BeforeEach(func() {
-						block = MakeTestBlock(bc, genesisChain, &types.GenerateBlockParams{
-							Transactions: []types.Transaction{
-								core.NewTx(core.TxTypeBalance, 1, receiver.Addr(), sender, "1", "2.4", 1532730722),
-							},
-							Creator:           sender,
-							Nonce:             util.EncodeNonce(1),
-							Difficulty:        new(big.Int).SetInt64(131136),
-							OverrideTimestamp: time.Now().Add(2 * time.Second).Unix(),
-						})
-					})
-
-					It("should return error", func() {
-						tp := txpool.New(1)
-						validator := NewBlockValidator(block, tp, bc, cfg, log)
-						validator.setContext(types.ContextBlock)
-						errs := validator.CheckTransactions()
-						Expect(errs).To(HaveLen(1))
-						err := fmt.Errorf("tx:0, error:transaction does not" +
-							" exist in the transactions pool")
-						Expect(errs).To(ContainElement(err))
+			Context("when transaction does not exist in pool", func() {
+				var block types.Block
+				BeforeEach(func() {
+					block = MakeTestBlock(bc, genesisChain, &types.GenerateBlockParams{
+						Transactions: []types.Transaction{
+							core.NewTx(core.TxTypeBalance, 1, receiver.Addr(), sender, "1", "2.4", 1532730722),
+						},
+						Creator:           sender,
+						Nonce:             util.EncodeNonce(1),
+						Difficulty:        new(big.Int).SetInt64(131136),
+						OverrideTimestamp: time.Now().Add(2 * time.Second).Unix(),
 					})
 				})
 
-				Context("when a sender X's current nonce is 1", func() {
+				It("should return no error", func() {
+					tp := txpool.New(1)
+					validator := NewBlockValidator(block, tp, bc, cfg, log)
+					validator.setContext(types.ContextBlock)
+					errs := validator.CheckTransactions()
+					Expect(errs).To(HaveLen(0))
+				})
+			})
 
-					var txs []types.Transaction
-					var block types.Block
+			Context("when a sender X's current nonce is 1", func() {
 
-					BeforeEach(func() {
-						now := time.Now().Unix()
-						txs = []types.Transaction{
-							core.NewTx(core.TxTypeBalance, 1, receiver.Addr(), sender, "1", "2.4", now),
-							core.NewTx(core.TxTypeBalance, 2, receiver.Addr(), sender, "1", "2.4", now),
-						}
-						for _, tx := range txs {
-							bc.txPool.Put(tx)
-						}
+				var txs []types.Transaction
+				var block types.Block
 
-						block = MakeTestBlock(bc, genesisChain, &types.GenerateBlockParams{
-							Transactions:      txs,
-							Creator:           sender,
-							Nonce:             util.EncodeNonce(1),
-							Difficulty:        new(big.Int).SetInt64(131136),
-							OverrideTimestamp: time.Now().Add(2 * time.Second).Unix(),
-						})
+				BeforeEach(func() {
+					now := time.Now().Unix()
+					txs = []types.Transaction{
+						core.NewTx(core.TxTypeBalance, 1, receiver.Addr(), sender, "1", "2.4", now),
+						core.NewTx(core.TxTypeBalance, 2, receiver.Addr(), sender, "1", "2.4", now),
+					}
+					for _, tx := range txs {
+						bc.txPool.Put(tx)
+					}
+
+					block = MakeTestBlock(bc, genesisChain, &types.GenerateBlockParams{
+						Transactions:      txs,
+						Creator:           sender,
+						Nonce:             util.EncodeNonce(1),
+						Difficulty:        new(big.Int).SetInt64(131136),
+						OverrideTimestamp: time.Now().Add(2 * time.Second).Unix(),
 					})
+				})
 
-					Context("and X has two transactions with nonce 2 and 3", func() {
-						It("should return error no error", func() {
-							validator := NewBlockValidator(block, bc.txPool, bc, cfg, log)
-							validator.setContext(types.ContextBlock)
-							errs := validator.CheckTransactions()
-							Expect(errs).To(HaveLen(0))
-						})
+				Context("and X has two transactions with nonce 2 and 3", func() {
+					It("should return error no error", func() {
+						validator := NewBlockValidator(block, bc.txPool, bc, cfg, log)
+						validator.setContext(types.ContextBlock)
+						errs := validator.CheckTransactions()
+						Expect(errs).To(HaveLen(0))
 					})
 				})
 			})

--- a/blockchain/process_test.go
+++ b/blockchain/process_test.go
@@ -745,30 +745,28 @@ var _ = Describe("ProcessBlock", func() {
 					block = MakeBlockWithNoPoolAddition(bc, genesisChain, sender, receiver)
 				})
 
-				It("should return error", func() {
+				It("should return no error", func() {
 					_, err = bc.ProcessBlock(block)
-					Expect(err).ToNot(BeNil())
-					Expect(err.Error()).To(Equal("tx:0, error:transaction does not " +
-						"exist in the transactions pool"))
+					Expect(err).To(BeNil())
 				})
 			})
 		})
 
 		When("ContextBlockSync is set", func() {
 
-			When("block includes a transaction that does not exist in the pool", func() {
-				var block types.Block
+			// When("block includes a transaction that does not exist in the pool", func() {
+			// 	var block types.Block
 
-				BeforeEach(func() {
-					block = MakeBlockWithNoPoolAddition(bc, genesisChain, sender, receiver)
-					block.SetValidationContexts(types.ContextBlockSync)
-				})
+			// 	BeforeEach(func() {
+			// 		block = MakeBlockWithNoPoolAddition(bc, genesisChain, sender, receiver)
+			// 		block.SetValidationContexts(types.ContextBlockSync)
+			// 	})
 
-				It("should be successful with no error", func() {
-					_, err = bc.ProcessBlock(block)
-					Expect(err).To(BeNil())
-				})
-			})
+			// 	It("should be successful with no error", func() {
+			// 		_, err = bc.ProcessBlock(block)
+			// 		Expect(err).To(BeNil())
+			// 	})
+			// })
 		})
 	})
 

--- a/blockchain/transaction_validator.go
+++ b/blockchain/transaction_validator.go
@@ -329,16 +329,6 @@ func (v *TxsValidator) consistencyCheck(tx types.Transaction, opts ...types.Call
 		return
 	}
 
-	// If the caller intends to validate a block that was
-	// received when the client is not sync with another peer,
-	// the transaction must exist in the transactions pool
-	if v.has(types.ContextBlock) && !v.has(types.ContextBlockSync) {
-		if !v.txpool.Has(tx) {
-			errs = append(errs, fieldErrorWithIndex(v.curIndex,
-				"", "transaction does not exist in the transactions pool"))
-		}
-	}
-
 	// No need performing nonce and balance checks for
 	// transactions inside a block that may be appended
 	// to a branch. This will be performed if the the

--- a/node/block_manager.go
+++ b/node/block_manager.go
@@ -191,8 +191,10 @@ func (bm *BlockManager) handleProcessedBlocks() error {
 		bm.miner.RestartWorkers()
 	}
 
-	// Relay the block to peers.
-	if b.(*core.Block).GetNumber() > 1 {
+	// Relay the block to peers only when the
+	// block is not the genesis block and we are
+	// not syncing with a peer.
+	if b.(*core.Block).GetNumber() > 1 && !bm.IsSyncing() {
 		bm.engine.Gossip().BroadcastBlock(b.(*core.Block),
 			bm.engine.PM().GetAcquaintedPeers())
 	}

--- a/node/block_manager.go
+++ b/node/block_manager.go
@@ -369,10 +369,7 @@ func (bm *BlockManager) sync() error {
 		var block core.Block
 		copier.Copy(&block, bb)
 
-		// Set core.ContextBlockSync to inform the block
-		// process to validate the block as synced block
-		// and set the broadcaster
-		block.SetValidationContexts(types.ContextBlockSync)
+		// Set the broadcaster
 		block.SetBroadcaster(peer)
 		bm.bestSyncCandidate.LastBlockSent = block.GetHash()
 

--- a/node/gossip/block.go
+++ b/node/gossip/block.go
@@ -218,7 +218,6 @@ func (g *Manager) RequestBlock(rp core.Engine, blockHash util.Hash) error {
 	var block core.Block
 	copier.Copy(&block, blockBody)
 	block.SetBroadcaster(rp)
-	block.SetValidationContexts(types.ContextBlockSync)
 	go g.engine.GetEventEmitter().Emit(core.EventProcessBlock, &block)
 
 	g.engine.GetHistory().AddMulti(cache.Sec(600), hk...)

--- a/types/others.go
+++ b/types/others.go
@@ -70,11 +70,6 @@ const (
 	// transaction that needs to be included in
 	// the transaction pool.
 	ContextTxPool
-
-	// ContextBlockSync represents validation context
-	// in which the intent is to validate a block
-	// received during block synchronization
-	ContextBlockSync
 )
 
 // GenerateBlockParams represents parameters


### PR DESCRIPTION
# Commit Summary

### Node
* Prevented blocks from being broadcast to peers when a node is syncing.

### Blockchain
* Removed validation check that required a block's transactions to exist in the transaction pool.
