### PR TITLE
Ignore Relayed Address With Matching Peer ID

### DIFF
--- a/makefile
+++ b/makefile
@@ -61,6 +61,7 @@ build-local-linux: release-linux
 start:
 	docker run -d \
 	 	--name elld \
+		-e ELLD_NET_VERSION="$(ELLD_NET_VERSION)" \
 		-e ELLD_NODE_ADDRESS=$(ELLD_NODE_ADDRESS) \
 		-e ELLD_NODE_BOOTSTRAPADDRS=$(ELLD_NODE_BOOTSTRAPADDRS) \
 		-e ELLD_NODE_ACCOUNT=$(ELLD_NODE_ACCOUNT) \

--- a/node/peermanager/peer_mgr.go
+++ b/node/peermanager/peer_mgr.go
@@ -200,6 +200,9 @@ func (m *Manager) ConnectToPeer(peerID string) error {
 		return fmt.Errorf("peer not found")
 	}
 
+	m.log.Debug("Attempting to connect to peer",
+		"PeerID", peer.ShortID())
+
 	gsp := m.localNode.Gossip()
 	err := gsp.SendHandshake(peer)
 	if err != nil {


### PR DESCRIPTION
- Incoming address with peer ID that is the same as the engine's Peer ID is ignored.
- Allow Network ID to be changed when starting a docker-based instance using make.