### PR TITLE
Return older chain when searching for chains

### DIFF
--- a/blockchain/api.go
+++ b/blockchain/api.go
@@ -16,9 +16,7 @@ import (
 
 // apiGetChains fetches a list of chains
 func (b *Blockchain) apiGetChains(interface{}) *jsonrpc.Response {
-	b.chl.RLock()
-	chains := b.chains
-	b.chl.RUnlock()
+	chains := b.copyChainsMap(nil)
 
 	var result []interface{}
 	for id, chain := range chains {
@@ -51,9 +49,7 @@ func (b *Blockchain) apiGetChains(interface{}) *jsonrpc.Response {
 
 // apiGetBlock fetches a block by number
 func (b *Blockchain) apiGetBlock(arg interface{}) *jsonrpc.Response {
-	b.chl.RLock()
-	mainChain := b.bestChain
-	b.chl.RUnlock()
+	mainChain := b.GetBestChain()
 
 	if mainChain == nil {
 		return jsonrpc.Error(types.ErrCodeQueryFailed, "best chain not set", nil)
@@ -78,9 +74,7 @@ func (b *Blockchain) apiGetBlock(arg interface{}) *jsonrpc.Response {
 
 // apiGetMinedBlocks fetches blocks mined by this node
 func (b *Blockchain) apiGetMinedBlocks(arg interface{}) *jsonrpc.Response {
-	b.chl.RLock()
-	mainChain := b.bestChain
-	b.chl.RUnlock()
+	mainChain := b.GetBestChain().(*Chain)
 
 	var opt core.ArgGetMinedBlock
 	if arg != nil {
@@ -88,9 +82,8 @@ func (b *Blockchain) apiGetMinedBlocks(arg interface{}) *jsonrpc.Response {
 		if !ok {
 			return jsonrpc.Error(types.ErrCodeUnexpectedArgType,
 				rpc.ErrMethodArgType("Map").Error(), nil)
-		} else {
-			mapstructure.Decode(decoded, &opt)
 		}
+		mapstructure.Decode(decoded, &opt)
 	}
 
 	result, hasMore, err := mainChain.GetMinedBlocks(&opt)
@@ -112,9 +105,7 @@ func (b *Blockchain) apiGetMinedBlocks(arg interface{}) *jsonrpc.Response {
 
 // apiGetTipBlock fetches the highest block on the main chain
 func (b *Blockchain) apiGetTipBlock(arg interface{}) *jsonrpc.Response {
-	b.chl.RLock()
-	mainChain := b.bestChain
-	b.chl.RUnlock()
+	mainChain := b.GetBestChain()
 
 	if mainChain == nil {
 		return jsonrpc.Error(types.ErrCodeQueryFailed, "best chain not set", nil)
@@ -135,9 +126,7 @@ func (b *Blockchain) apiGetTipBlock(arg interface{}) *jsonrpc.Response {
 
 // apiGetBlockByHash fetches a block by hash
 func (b *Blockchain) apiGetBlockByHash(arg interface{}) *jsonrpc.Response {
-	b.chl.RLock()
-	mainChain := b.bestChain
-	b.chl.RUnlock()
+	mainChain := b.GetBestChain().(*Chain)
 
 	if mainChain == nil {
 		return jsonrpc.Error(types.ErrCodeQueryFailed, "best chain not set", nil)
@@ -179,9 +168,7 @@ func (b *Blockchain) apiGetOrphans(arg interface{}) *jsonrpc.Response {
 
 // apiGetBestchain fetches the best chain
 func (b *Blockchain) apiGetBestchain(arg interface{}) *jsonrpc.Response {
-	b.chl.RLock()
-	mainChain := b.bestChain
-	b.chl.RUnlock()
+	mainChain := b.GetBestChain().(*Chain)
 
 	if mainChain == nil {
 		return jsonrpc.Error(types.ErrCodeQueryFailed, "best chain not set", nil)
@@ -364,9 +351,7 @@ func (b *Blockchain) apiGetTransactionFromPool(arg interface{}) *jsonrpc.Respons
 // difficulty of the main chain
 func (b *Blockchain) apiGetDifficultyInfo(arg interface{}) *jsonrpc.Response {
 
-	b.chl.RLock()
-	mainChain := b.bestChain
-	b.chl.RUnlock()
+	mainChain := b.GetBestChain()
 
 	if mainChain == nil {
 		return jsonrpc.Error(types.ErrCodeQueryFailed, "best chain not set", nil)
@@ -389,9 +374,7 @@ func (b *Blockchain) apiGetDifficultyInfo(arg interface{}) *jsonrpc.Response {
 // apiListAccounts gets all accounts
 func (b *Blockchain) apiListAccounts(arg interface{}) *jsonrpc.Response {
 
-	b.chl.RLock()
-	mainChain := b.bestChain
-	b.chl.RUnlock()
+	mainChain := b.GetBestChain().(*Chain)
 
 	if mainChain == nil {
 		return jsonrpc.Error(types.ErrCodeQueryFailed, "best chain not set", nil)
@@ -478,7 +461,6 @@ func (b *Blockchain) apiSuggestNonce(arg interface{}) *jsonrpc.Response {
 		}
 	}
 
-	// pp.Println(txPoolNonces, suggested)
 	return jsonrpc.Success(suggested)
 }
 

--- a/blockchain/block.go
+++ b/blockchain/block.go
@@ -19,7 +19,7 @@ import (
 func (b *Blockchain) getBlockByHash(args ...interface{}) interface{} {
 	hash := args[0].(util.Hash)
 	opts := args[1].([]types.CallOp)
-	for _, chain := range b.chains {
+	for _, chain := range b.copyChainsMap(nil) {
 		block, err := chain.getBlockByHash(hash, opts...)
 		if err != nil {
 			if err != core.ErrBlockNotFound {
@@ -35,9 +35,7 @@ func (b *Blockchain) getBlockByHash(args ...interface{}) interface{} {
 // HaveBlock checks whether we have a block matching
 // the hash in any of the known chains
 func (b *Blockchain) HaveBlock(hash util.Hash) (bool, error) {
-	b.chl.RLock()
-	defer b.chl.RUnlock()
-	chains := b.chains
+	chains := b.copyChainsMap(nil)
 	for _, chain := range chains {
 		has, err := chain.hasBlock(hash)
 		if err != nil {
@@ -237,10 +235,7 @@ func (b *Blockchain) Generate(params *types.GenerateBlockParams, opts ...types.C
 // GetBlock finds a block in any chain with a matching
 // block number and hash.
 func (b *Blockchain) GetBlock(number uint64, hash util.Hash) (types.Block, error) {
-	b.chl.RLock()
-	defer b.chl.RUnlock()
-	chains := b.chains
-	for _, chain := range chains {
+	for _, chain := range b.copyChainsMap(nil) {
 		block, err := chain.getBlockByNumberAndHash(number, hash)
 		if err != nil {
 			if err != core.ErrBlockNotFound {
@@ -255,9 +250,7 @@ func (b *Blockchain) GetBlock(number uint64, hash util.Hash) (types.Block, error
 
 // GetBlockByHash finds a block in any chain with a matching hash.
 func (b *Blockchain) GetBlockByHash(hash util.Hash, opts ...types.CallOp) (types.Block, error) {
-	b.chl.RLock()
-	defer b.chl.RUnlock()
-	for _, chain := range b.chains {
+	for _, chain := range b.copyChainsMap(nil) {
 		block, err := chain.getBlockByHash(hash, opts...)
 		if err != nil {
 			if err != core.ErrBlockNotFound {

--- a/blockchain/block_validator.go
+++ b/blockchain/block_validator.go
@@ -223,7 +223,6 @@ func (v *BlockValidator) CheckFields() (errs []error) {
 		errs = append(errs, fieldError("hash", "hash is required"))
 	} else if v.block.GetHeader() != nil && !v.block.GetHash().
 		Equal(v.block.ComputeHash()) {
-		// pp.Println(v.block.GetHash().HexStr(), "Computed:", v.block.ComputeHash().HexStr())
 		errs = append(errs, fieldError("hash", "hash is not correct"))
 	}
 

--- a/blockchain/blockchain.go
+++ b/blockchain/blockchain.go
@@ -8,6 +8,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/thoas/go-funk"
+
 	"github.com/ellcrys/elld/crypto"
 	"github.com/syndtr/goleveldb/leveldb"
 
@@ -244,7 +246,7 @@ func (b *Blockchain) Up() error {
 func (b *Blockchain) getRootChain() *Chain {
 	b.chl.RLock()
 	defer b.chl.RUnlock()
-	for _, c := range b.chains {
+	for _, c := range b.copyChains(nil) {
 		if !c.HasParent() {
 			return c
 		}
@@ -252,7 +254,6 @@ func (b *Blockchain) getRootChain() *Chain {
 	return nil
 }
 
-// getBlockByHash finds and returns a block by hash only
 // SetEventEmitter sets the event emitter
 func (b *Blockchain) SetEventEmitter(ee *emitter.Emitter) {
 	b.eventEmitter = ee
@@ -356,23 +357,70 @@ func (b *Blockchain) removeChain(chain *Chain) {
 	return
 }
 
-// findChainByBlockHash finds the chain where the given block
-// hash exists. It returns the block, the chain, the header of
-// highest block in the chain.
-func (b *Blockchain) findChainByBlockHash(hash util.Hash,
-	opts ...types.CallOp) (block types.Block, chain *Chain,
-	chainTipHeader types.Header, err error) {
-
+// copyChains all known chains into a slice and will
+// exclude any chain whose ID is listed in ex.
+func (b *Blockchain) copyChains(ex []util.String) []*Chain {
+	if ex == nil {
+		ex = []util.String{}
+	}
 	b.chl.RLock()
 	defer b.chl.RUnlock()
-	chains := b.chains
+	chains := []*Chain{}
+	for _, ch := range b.chains {
+		if funk.Contains(ex, ch.GetID()) {
+			continue
+		}
+		chains = append(chains, ch)
+	}
+	return chains
+}
 
-	for _, chain := range chains {
+// copyChainsMap all known chains into another map and will
+// exclude any chain whose ID is listed in ex.
+func (b *Blockchain) copyChainsMap(ex []util.String) map[util.String]*Chain {
+	if ex == nil {
+		ex = []util.String{}
+	}
+	b.chl.RLock()
+	defer b.chl.RUnlock()
+	chains := map[util.String]*Chain{}
+	for _, ch := range b.chains {
+		if funk.Contains(ex, ch.GetID()) {
+			continue
+		}
+		chains[ch.GetID()] = ch
+	}
+	return chains
+}
 
-		// Find the block by its hash. If we don't
-		// find the block in this chain, we continue to the
-		// next chain.
-		block, err := chain.getBlockByHash(hash, opts...)
+// findChainByBlockHash finds the chain where the given block
+// hash exists. It returns the block, the chain, the header of
+// highest block in the chain. If multiple chains match, the
+// oldest is chosen.
+func (b *Blockchain) findChainByBlockHash(hash util.Hash, opts ...types.CallOp) (block types.Block,
+	chain *Chain, chainTipHeader types.Header, err error) {
+
+	// Get all known chains. Because we need to first check the
+	// main chain before any other, we filter it our from
+	// the call to copyChains but then append it to the final
+	// chain slice so that it is the first in the slice.
+	var chains []*Chain
+	var excludeList []util.String
+	mainChain := b.GetBestChain()
+	if mainChain != nil {
+		excludeList = append(excludeList, mainChain.GetID())
+		chains = b.copyChains(excludeList)
+		chains = append([]*Chain{mainChain.(*Chain)}, chains...)
+	} else {
+		chains = b.copyChains(excludeList)
+	}
+
+	oldestChainTimestamp := int64(0)
+	for _, _chain := range chains {
+
+		// Find the block in the chain by its hash. If we don't
+		// find the block on this chain, we continue to the next chain.
+		_block, err := _chain.getBlockByHash(hash, opts...)
 		if err != nil {
 			if err != core.ErrBlockNotFound {
 				return nil, nil, nil, err
@@ -380,19 +428,38 @@ func (b *Blockchain) findChainByBlockHash(hash util.Hash,
 			continue
 		}
 
-		// At the point, we have found chain the block belongs to.
-		// Next we get the header of the block at the tip of the chain.
-		chainTipHeader, err := chain.Current(opts...)
+		// Ok, so the block was found on this chain. We will ignore the
+		// chain if it is younger than the last chain that was found.
+		// But if the oldest chain timestamp is not set, we set it to
+		// this chain.
+		if oldestChainTimestamp == 0 {
+			oldestChainTimestamp = _chain.GetInfo().GetTimestamp()
+		} else if _chain.GetInfo().GetTimestamp() > oldestChainTimestamp {
+			continue
+		} else {
+			// If the chain's timestamp is the same as the previous
+			// oldest chain, we'll ignore it
+			if _chain.GetInfo().GetTimestamp() == oldestChainTimestamp {
+				continue
+			}
+			oldestChainTimestamp = _chain.GetInfo().GetTimestamp()
+		}
+
+		// At the point, we have found a chain.
+		// But we will collect it and find more chains.
+		_chainTipHeader, err := _chain.Current(opts...)
 		if err != nil {
 			if err != core.ErrBlockNotFound {
 				return nil, nil, nil, err
 			}
 		}
 
-		return block, chain, chainTipHeader, nil
+		chain = _chain
+		block = _block
+		chainTipHeader = _chainTipHeader
 	}
 
-	return nil, nil, nil, nil
+	return
 }
 
 // addRejectedBlock adds the block to the rejection cache.
@@ -435,9 +502,7 @@ func (b *Blockchain) NewChainFromChainInfo(ci types.ChainInfo) *Chain {
 // findChainInfo finds information about chain
 func (b *Blockchain) findChainInfo(chainID util.String) (*core.ChainInfo, error) {
 
-	b.chl.RLock()
-	chains := b.chains
-	b.chl.RUnlock()
+	chains := b.copyChainsMap(nil)
 
 	// check whether the chain exists in the cache
 	if chain, ok := chains[chainID]; ok {
@@ -615,7 +680,7 @@ func (b *Blockchain) GetChainReaderByHash(hash util.Hash) types.ChainReaderFacto
 func (b *Blockchain) GetChainsReader() (readers []types.ChainReaderFactory) {
 	b.chl.RLock()
 	defer b.chl.RUnlock()
-	chains := b.chains
+	chains := b.copyChainsMap(nil)
 	for _, c := range chains {
 		readers = append(readers, NewChainReader(c))
 	}

--- a/blockchain/blockchain.go
+++ b/blockchain/blockchain.go
@@ -244,8 +244,6 @@ func (b *Blockchain) Up() error {
 // getRootChain finds the root chain of the tree.
 // This is usually the main chain and it has no branch.
 func (b *Blockchain) getRootChain() *Chain {
-	b.chl.RLock()
-	defer b.chl.RUnlock()
 	for _, c := range b.copyChains(nil) {
 		if !c.HasParent() {
 			return c

--- a/blockchain/process.go
+++ b/blockchain/process.go
@@ -524,7 +524,8 @@ func (b *Blockchain) ProcessBlock(block types.Block,
 	defer b.processLock.Unlock()
 
 	b.log.Debug("Processing block", "BlockNo", block.GetNumber(),
-		"Hash", block.GetHash().SS())
+		"Hash", block.GetHash().SS(),
+		"ChainID", b.GetBestChain().GetID())
 
 	// If ever we forgot to set the transaction pool,
 	// the client should be forced to exit.

--- a/blockchain/reorg.go
+++ b/blockchain/reorg.go
@@ -57,9 +57,7 @@ func (b *Blockchain) chooseBestChain(opts ...types.CallOp) (*Chain, error) {
 		txOp.SetFinishable(!hasInjectTx).Discard()
 	}()
 
-	b.chl.RLock()
-	chains := b.chains
-	b.chl.RUnlock()
+	chains := b.copyChainsMap(nil)
 
 	// If no chain exists on the blockchain, return nil
 	if len(chains) == 0 {
@@ -212,6 +210,8 @@ start:
 			return fmt.Errorf("Reorganization has failed: %s", err)
 		}
 		b.setReOrgStatus(false)
+
+		b.log.Info("Parent and child re-organised")
 
 		// Go back to the top to re-determine the new proposed chain naturally.
 		goto start


### PR DESCRIPTION
# Commit Summary

### Blockchain

`findChainByBlockHash` now:
- Prioritizes older chains.
- Searches the main chain first.

Introduced `copyChains` and `copyChainsMap`

- Both copy chains into slice and map containers respectively
- Should be used where a copy is required without holding a lock for long.
- Replace occurrences where locks are held to read chain index.